### PR TITLE
handle_message: Always return a response

### DIFF
--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -34,9 +34,16 @@ pub mod version {
     Debug, Clone, Copy, SerializedSize, Serialize, Deserialize, PartialEq, Eq,
 )]
 pub struct Request {
+    pub header: RequestHeader,
+    pub kind: RequestKind,
+}
+
+#[derive(
+    Debug, Clone, Copy, SerializedSize, Serialize, Deserialize, PartialEq, Eq,
+)]
+pub struct RequestHeader {
     pub version: u32,
     pub request_id: u32,
-    pub kind: RequestKind,
 }
 
 #[derive(
@@ -677,8 +684,10 @@ mod tests {
     #[test]
     fn test_serialize_with_trailing_data() {
         let mut out = [0; MAX_SERIALIZED_SIZE];
-        let header =
-            Request { version: 1, request_id: 2, kind: RequestKind::Discover };
+        let header = Request {
+            header: RequestHeader { version: 1, request_id: 2 },
+            kind: RequestKind::Discover,
+        };
         let data_vecs = &[
             vec![0; 256],
             vec![1; 256],

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -18,6 +18,7 @@ use gateway_messages::IgnitionCommand;
 use gateway_messages::IgnitionState;
 use gateway_messages::PowerState;
 use gateway_messages::Request;
+use gateway_messages::RequestHeader;
 use gateway_messages::RequestKind;
 use gateway_messages::ResponseError;
 use gateway_messages::ResponseKind;
@@ -769,8 +770,13 @@ impl Inner {
     ) -> Result<(SocketAddrV6, ResponseKind)> {
         // Build and serialize our request once.
         self.request_id += 1;
-        let request =
-            Request { version: version::V1, request_id: self.request_id, kind };
+        let request = Request {
+            header: RequestHeader {
+                version: version::V1,
+                request_id: self.request_id,
+            },
+            kind,
+        };
 
         let mut outgoing_buf = [0; gateway_messages::MAX_SERIALIZED_SIZE];
         let n = match trailing_data {
@@ -806,7 +812,7 @@ impl Inner {
             match self
                 .rpc_call_one_attempt(
                     addr,
-                    request.request_id,
+                    request.header.request_id,
                     outgoing_buf,
                     incoming_buf,
                 )


### PR DESCRIPTION
This moves the handling of invalid requests from `sp_impl::handle_message()`'s caller to `sp_impl::handle_message()` itself, making the latter infallible. The implementation of this moves away from using `hubpack::deserialize(_)` on the full `Request`: we now manually deserialize the first two fields (version and request ID), so that any hubpack failures down the line (e.g., an unknown message variant) don't prevent us from returning a response that includes the request ID.

Adds a `ResponseError::BadRequest(reason)` variant.

This PR looks bigger than it is - the bulk of the diff is a new `mod test { .. }`, and the bulk of that is in `impl SpHandler for FakeHandler { .. }` where almost all methods are just left as `todo!()` since the tests don't call them.