### PR TITLE
Add preliminary device inventory

### DIFF
--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -97,6 +97,9 @@ enum SpCommand {
     /// Ask SP for its current state.
     State,
 
+    /// Ask SP for its inventory.
+    Inventory,
+
     /// Attach to the SP's USART.
     UsartAttach {
         /// Put the local terminal in raw mode.
@@ -222,6 +225,22 @@ async fn main() -> Result<()> {
         }
         Some(SpCommand::State) => {
             info!(log, "{:?}", sp.state().await?);
+        }
+        Some(SpCommand::Inventory) => {
+            let inventory = sp.inventory().await?;
+            println!(
+                "{:<12} {:>10} {:<16} {:<}",
+                "STATUS", "MEAS.CHAN.", "DEVICE", "DESCRIPTION"
+            );
+            for d in inventory.devices {
+                println!(
+                    "{:<12} {:>10} {:<16} {:<}",
+                    format!("{:?}", d.presence),
+                    d.num_measurement_channels,
+                    d.device,
+                    d.description
+                );
+            }
         }
         Some(SpCommand::UsartAttach { raw, stdin_buffer_time_millis }) => {
             usart::run(

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -690,13 +690,29 @@ impl GatewayMessage for SpMessage {}
 impl private::Sealed for Request {}
 impl private::Sealed for SpMessage {}
 
+/// Minimum guaranteed space for trailing data in a [`Request`] packet.
+///
+/// Depending on the [`Request`] payload, there may be more space for trailing
+/// data than indicated by this constant; this specifies the minimum amount
+/// available regardless of the request type.
+pub const MIN_REQUEST_TRAILING_TRAILING_DATA_LEN: usize =
+    MAX_SERIALIZED_SIZE - Request::MAX_SIZE;
+
+/// Minimum guaranteed space for trailing data in an [`SpMessage`] packet.
+///
+/// Depending on the [`SpMessage`] payload, there may be more space for trailing
+/// data than indicated by this constant; this specifies the minimum amount
+/// available regardless of the message type.
+pub const MIN_SP_MESSAGE_TRAILING_TRAILING_DATA_LEN: usize =
+    MAX_SERIALIZED_SIZE - SpMessage::MAX_SIZE;
+
 // `GatewayMessage` implementers can be followed by binary data; we want the
 // majority of our packet to be available for that data. Statically check that
 // our serialized message headers haven't gotten too large. The specific value
 // here is arbitrary; if this check starts failing, it's probably fine to reduce
 // it some. The check is here to force us to think about it.
-const_assert!(MAX_SERIALIZED_SIZE - Request::MAX_SIZE > 700);
-const_assert!(MAX_SERIALIZED_SIZE - SpMessage::MAX_SIZE > 700);
+const_assert!(MIN_REQUEST_TRAILING_TRAILING_DATA_LEN > 700);
+const_assert!(MIN_SP_MESSAGE_TRAILING_TRAILING_DATA_LEN > 700);
 
 /// Returns `(serialized_size, data_bytes_written)` where `serialized_size` is
 /// the message size written to `out` and `data_bytes_written` is the number of

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -176,7 +176,7 @@ pub enum PowerState {
 /// Metadata describing the set of device descriptions present in this response.
 ///
 /// Followed by trailing data containing a sequence of [`tlv`]-encoded
-/// [`DeviceDescription`]s.
+/// [`DeviceDescriptionHeader`]s and their associated data.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, SerializedSize,
 )]
@@ -187,33 +187,33 @@ pub struct DeviceInventoryPage {
     pub total_devices: u32,
 }
 
-/// Description of a single device.
+/// Header for the description of a single device.
 ///
 /// Always packed into a [`tlv`] triple containing:
 ///
 /// ```text
 /// [
-///     DeviceDescription::TAG
+///     DeviceDescriptionHeader::TAG
 ///     | length
-///     | hubpack-serialized DeviceDescription
+///     | hubpack-serialized DeviceDescriptionHeader
 ///     | device
 ///     | description
 /// ]
 /// ```
 ///
 /// where `device` and `description` are UTF8 strings whose lengths are included
-/// in the `DeviceDescription`.
+/// in the `DeviceDescriptionHeader`.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, SerializedSize,
 )]
-pub struct DeviceDescription {
+pub struct DeviceDescriptionHeader {
     pub device_len: u32,
     pub description_len: u32,
     pub num_measurement_channels: u32,
     pub presence: DevicePresence,
 }
 
-impl DeviceDescription {
+impl DeviceDescriptionHeader {
     pub const TAG: tlv::Tag = tlv::Tag(*b"DSC0");
 }
 

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -304,9 +304,16 @@ fn encode_device_inventory<H: SpHandler>(
                 total_tlv_len += n;
                 out = &mut out[n..];
             }
+            Err(tlv::EncodeError::Custom(infallible)) => {
+                // A bit of type system magic here; our custom error type
+                // (`Infallible`) cannot be instantiated. We can
+                // provide an empty match to teach the type system that an
+                // `Infallible` (which can't exist) can this branch is
+                // unreachable without needing to explicitly panic.
+                match infallible {}
+            }
             // We checked the length above; this error isn't possible.
             Err(tlv::EncodeError::BufferTooSmall) => panic!(),
-            Err(tlv::EncodeError::Custom(infallible)) => match infallible {},
         }
 
         device_index += 1;
@@ -351,7 +358,7 @@ fn read_request_header(data: &[u8]) -> (u32, Result<&[u8], ResponseError>) {
 /// are handled by `read_request_header`) and calls `handler`.
 ///
 /// If the response kind needs to generate trailing data, returns `(Ok(_),
-/// Some(_)`, and our caller is resposnible for handling that generation.
+/// Some(_)`, and our caller is responsible for handling that generation.
 /// Otherwise, returns `(result, None)`.
 fn handle_message_impl<H: SpHandler>(
     sender: SocketAddrV6,

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -9,6 +9,7 @@ use crate::version;
 use crate::BadRequestReason;
 use crate::BulkIgnitionState;
 use crate::ComponentUpdatePrepare;
+use crate::DeviceDescriptionHeader;
 use crate::DeviceInventoryPage;
 use crate::DevicePresence;
 use crate::DiscoverResponse;
@@ -50,7 +51,7 @@ pub struct DeviceDescription<'a> {
     pub presence: DevicePresence,
 }
 
-impl From<DeviceDescription<'_>> for crate::DeviceDescription {
+impl From<DeviceDescription<'_>> for DeviceDescriptionHeader {
     fn from(dev: DeviceDescription<'_>) -> Self {
         Self {
             device_len: dev.device.len() as u32,
@@ -266,8 +267,6 @@ fn encode_device_inventory<H: SpHandler>(
     total_devices: u32,
     handler: &mut H,
 ) -> usize {
-    use crate::DeviceDescription as DeviceDescriptionHeader;
-
     let mut total_tlv_len = 0;
     while device_index < total_devices {
         let dev = handler.device_description(device_index);

--- a/gateway-sp-comms/src/communicator.rs
+++ b/gateway-sp-comms/src/communicator.rs
@@ -18,6 +18,7 @@ use futures::stream::FuturesUnordered;
 use futures::Future;
 use futures::Stream;
 use gateway_messages::BulkIgnitionState;
+use gateway_messages::DeviceInventoryPage;
 use gateway_messages::DiscoverResponse;
 use gateway_messages::IgnitionCommand;
 use gateway_messages::IgnitionState;
@@ -370,6 +371,8 @@ pub(crate) trait ResponseKindExt {
     fn expect_set_power_state_ack(self) -> Result<(), BadResponseType>;
 
     fn expect_sys_reset_prepare_ack(self) -> Result<(), BadResponseType>;
+
+    fn expect_inventory(self) -> Result<DeviceInventoryPage, BadResponseType>;
 }
 
 impl ResponseKindExt for ResponseKind {
@@ -415,6 +418,7 @@ impl ResponseKindExt for ResponseKind {
             ResponseKind::ResetPrepareAck => {
                 response_kind_names::RESET_PREPARE_ACK
             }
+            ResponseKind::Inventory(_) => response_kind_names::INVENTORY,
         }
     }
 
@@ -583,6 +587,16 @@ impl ResponseKindExt for ResponseKind {
             }),
         }
     }
+
+    fn expect_inventory(self) -> Result<DeviceInventoryPage, BadResponseType> {
+        match self {
+            ResponseKind::Inventory(page) => Ok(page),
+            other => Err(BadResponseType {
+                expected: response_kind_names::INVENTORY,
+                got: other.name(),
+            }),
+        }
+    }
 }
 
 mod response_kind_names {
@@ -606,4 +620,5 @@ mod response_kind_names {
     pub(super) const POWER_STATE: &str = "power_state";
     pub(super) const SET_POWER_STATE_ACK: &str = "set_power_state_ack";
     pub(super) const RESET_PREPARE_ACK: &str = "reset_prepare_ack";
+    pub(super) const INVENTORY: &str = "inventory";
 }

--- a/gateway-sp-comms/src/error.rs
+++ b/gateway-sp-comms/src/error.rs
@@ -27,6 +27,10 @@ pub enum SpCommunicationError {
     SpError(#[from] ResponseError),
     #[error("Bogus serial console state; detach and reattach")]
     BogusSerialConsoleState,
+    #[error("SP claimed more inventory devices than we can accept")]
+    InventoryTooLarge,
+    #[error("Invalid inventory pagination state")]
+    InvalidInventoryPagination,
 }
 
 #[derive(Debug, Error)]

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -14,7 +14,7 @@ use backoff::backoff::Backoff;
 use gateway_messages::tlv;
 use gateway_messages::version;
 use gateway_messages::BulkIgnitionState;
-use gateway_messages::DeviceDescription;
+use gateway_messages::DeviceDescriptionHeader;
 use gateway_messages::DevicePresence;
 use gateway_messages::IgnitionCommand;
 use gateway_messages::IgnitionState;
@@ -437,13 +437,14 @@ fn decode_tlv_devices(
 
         // Do we know how to interpret this tag?
         match tag {
-            DeviceDescription::TAG => {
+            DeviceDescriptionHeader::TAG => {
                 // Peel header out of the value.
-                let (header, data) =
-                    gateway_messages::deserialize::<DeviceDescription>(value)
-                        .map_err(|_| {
-                        SpCommunicationError::InvalidInventoryPagination
-                    })?;
+                let (header, data) = gateway_messages::deserialize::<
+                    DeviceDescriptionHeader,
+                >(value)
+                .map_err(|_| {
+                    SpCommunicationError::InvalidInventoryPagination
+                })?;
 
                 // Make sure the data length matches the header's claims.
                 let device_len = header.device_len as usize;

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -11,7 +11,6 @@ use crate::error::BadResponseType;
 use crate::error::SpCommunicationError;
 use crate::error::UpdateError;
 use backoff::backoff::Backoff;
-use gateway_messages::sp_impl;
 use gateway_messages::version;
 use gateway_messages::BulkIgnitionState;
 use gateway_messages::IgnitionCommand;
@@ -127,7 +126,7 @@ impl SingleSp {
     /// This will fail if this SP is not connected to an ignition controller.
     pub async fn ignition_state(&self, target: u8) -> Result<IgnitionState> {
         self.rpc(RequestKind::IgnitionState { target }).await.and_then(
-            |(_peer, response)| {
+            |(_peer, response, _data)| {
                 response.expect_ignition_state().map_err(Into::into)
             },
         )
@@ -138,7 +137,7 @@ impl SingleSp {
     /// This will fail if this SP is not connected to an ignition controller.
     pub async fn bulk_ignition_state(&self) -> Result<BulkIgnitionState> {
         self.rpc(RequestKind::BulkIgnitionState).await.and_then(
-            |(_peer, response)| {
+            |(_peer, response, _data)| {
                 response.expect_bulk_ignition_state().map_err(Into::into)
             },
         )
@@ -154,16 +153,18 @@ impl SingleSp {
     ) -> Result<()> {
         self.rpc(RequestKind::IgnitionCommand { target, command })
             .await
-            .and_then(|(_peer, response)| {
+            .and_then(|(_peer, response, _data)| {
                 response.expect_ignition_command_ack().map_err(Into::into)
             })
     }
 
     /// Request the state of the SP.
     pub async fn state(&self) -> Result<SpState> {
-        self.rpc(RequestKind::SpState).await.and_then(|(_peer, response)| {
-            response.expect_sp_state().map_err(Into::into)
-        })
+        self.rpc(RequestKind::SpState).await.and_then(
+            |(_peer, response, _data)| {
+                response.expect_sp_state().map_err(Into::into)
+            },
+        )
     }
 
     /// Update a component of the SP (or the SP itself!).
@@ -225,7 +226,7 @@ impl SingleSp {
     ) -> Result<()> {
         self.rpc(RequestKind::UpdateAbort { component, id: update_id.into() })
             .await
-            .and_then(|(_peer, response)| {
+            .and_then(|(_peer, response, _data)| {
                 response.expect_update_abort_ack().map_err(Into::into)
             })
     }
@@ -233,7 +234,7 @@ impl SingleSp {
     /// Get the current power state.
     pub async fn power_state(&self) -> Result<PowerState> {
         self.rpc(RequestKind::GetPowerState).await.and_then(
-            |(_peer, response)| {
+            |(_peer, response, _data)| {
                 response.expect_power_state().map_err(Into::into)
             },
         )
@@ -242,7 +243,7 @@ impl SingleSp {
     /// Set the current power state.
     pub async fn set_power_state(&self, power_state: PowerState) -> Result<()> {
         self.rpc(RequestKind::SetPowerState(power_state)).await.and_then(
-            |(_peer, response)| {
+            |(_peer, response, _data)| {
                 response.expect_set_power_state_ack().map_err(Into::into)
             },
         )
@@ -260,7 +261,7 @@ impl SingleSp {
     /// the case of updates).
     pub async fn reset_prepare(&self) -> Result<()> {
         self.rpc(RequestKind::ResetPrepare).await.and_then(
-            |(_peer, response)| {
+            |(_peer, response, _data)| {
                 response.expect_sys_reset_prepare_ack().map_err(Into::into)
             },
         )
@@ -273,7 +274,7 @@ impl SingleSp {
         // Reset trigger should retry until we get back an error indicating the
         // SP wasn't expecting a reset trigger (because it has reset!).
         match self.rpc(RequestKind::ResetTrigger).await {
-            Ok((_peer, response)) => {
+            Ok((_peer, response, _data)) => {
                 Err(SpCommunicationError::BadResponseType(BadResponseType {
                     expected: "system-reset",
                     got: response.name(),
@@ -328,7 +329,7 @@ impl SingleSp {
     pub(crate) async fn rpc(
         &self,
         kind: RequestKind,
-    ) -> Result<(SocketAddrV6, ResponseKind)> {
+    ) -> Result<(SocketAddrV6, ResponseKind, Vec<u8>)> {
         rpc(&self.cmds_tx, kind, None).await.result
     }
 }
@@ -336,20 +337,20 @@ impl SingleSp {
 async fn rpc_with_trailing_data(
     inner_tx: &mpsc::Sender<InnerCommand>,
     kind: RequestKind,
-    trailing_data: Cursor<Vec<u8>>,
-) -> (Result<(SocketAddrV6, ResponseKind)>, Cursor<Vec<u8>>) {
-    let RpcResponse { result, trailing_data } =
-        rpc(inner_tx, kind, Some(trailing_data)).await;
+    our_trailing_data: Cursor<Vec<u8>>,
+) -> (Result<(SocketAddrV6, ResponseKind, Vec<u8>)>, Cursor<Vec<u8>>) {
+    let RpcResponse { result, our_trailing_data } =
+        rpc(inner_tx, kind, Some(our_trailing_data)).await;
 
     // We sent `Some(_)` trailing data, so we get `Some(_)` back; unwrap it
     // so our caller can remain ignorant of this detail.
-    (result, trailing_data.unwrap())
+    (result, our_trailing_data.unwrap())
 }
 
 async fn rpc(
     inner_tx: &mpsc::Sender<InnerCommand>,
     kind: RequestKind,
-    trailing_data: Option<Cursor<Vec<u8>>>,
+    our_trailing_data: Option<Cursor<Vec<u8>>>,
 ) -> RpcResponse {
     let (resp_tx, resp_rx) = oneshot::channel();
 
@@ -358,7 +359,7 @@ async fn rpc(
     inner_tx
         .send(InnerCommand::Rpc(RpcRequest {
             kind,
-            trailing_data,
+            our_trailing_data,
             response_tx: resp_tx,
         }))
         .await
@@ -418,7 +419,7 @@ impl AttachedSerialConsoleSend {
                 - CursorExt::remaining_slice(&new_data).len())
                 as u64;
 
-            let n = result.and_then(|(_peer, response)| {
+            let n = result.and_then(|(_peer, response, _data)| {
                 response.expect_serial_console_write_ack().map_err(Into::into)
             })?;
 
@@ -486,27 +487,27 @@ impl AttachedSerialConsoleRecv {
 }
 
 // All RPC request/responses are handled by message passing to the `Inner` task
-// below. `trailing_data` deserves some extra documentation: Some packet types
+// below. `our_trailing_data` deserves some extra documentation: Some packet types
 // (e.g., update chunks) want to send potentially-large binary data. We
 // serialize this data with `gateway_messages::serialize_with_trailing_data()`,
 // which appends as much data as will fit after the message header, but the
 // caller doesn't know how much data that is until serialization happens. To
 // handle this, we traffic in `Cursor<Vec<u8>>`s for communicating trailing data
-// to `Inner`. If `trailing_data` in the `RpcRequest` is `Some(_)`, it will
+// to `Inner`. If `our_trailing_data` in the `RpcRequest` is `Some(_)`, it will
 // always be returned as `Some(_)` in the response as well, and the cursor will
 // have been advanced by however much data was packed into the single RPC packet
 // exchanged with the SP.
 #[derive(Debug)]
 struct RpcRequest {
     kind: RequestKind,
-    trailing_data: Option<Cursor<Vec<u8>>>,
+    our_trailing_data: Option<Cursor<Vec<u8>>>,
     response_tx: oneshot::Sender<RpcResponse>,
 }
 
 #[derive(Debug)]
 struct RpcResponse {
-    result: Result<(SocketAddrV6, ResponseKind)>,
-    trailing_data: Option<Cursor<Vec<u8>>>,
+    result: Result<(SocketAddrV6, ResponseKind, Vec<u8>)>,
+    our_trailing_data: Option<Cursor<Vec<u8>>>,
 }
 
 #[derive(Debug)]
@@ -649,7 +650,7 @@ impl Inner {
         &mut self,
         incoming_buf: &mut [u8; gateway_messages::MAX_SERIALIZED_SIZE],
     ) -> Result<SocketAddrV6> {
-        let (addr, response) = self
+        let (addr, response, _data) = self
             .rpc_call(
                 self.discovery_addr,
                 RequestKind::Discover,
@@ -680,12 +681,14 @@ impl Inner {
                     .rpc_call(
                         sp_addr,
                         rpc.kind,
-                        rpc.trailing_data.as_mut(),
+                        rpc.our_trailing_data.as_mut(),
                         incoming_buf,
                     )
                     .await;
-                let response =
-                    RpcResponse { result, trailing_data: rpc.trailing_data };
+                let response = RpcResponse {
+                    result,
+                    our_trailing_data: rpc.our_trailing_data,
+                };
 
                 if rpc.response_tx.send(response).is_err() {
                     warn!(
@@ -717,9 +720,9 @@ impl Inner {
         &mut self,
         result: Result<(SocketAddrV6, SpMessage, &[u8])>,
     ) {
-        let (peer, message, trailing_data) = match result {
-            Ok((peer, message, trailing_data)) => {
-                (peer, message, trailing_data)
+        let (peer, message, sp_trailing_data) = match result {
+            Ok((peer, message, sp_trailing_data)) => {
+                (peer, message, sp_trailing_data)
             }
             Err(err) => {
                 error!(
@@ -756,7 +759,11 @@ impl Inner {
                 );
             }
             SpMessageKind::SerialConsole { component, offset } => {
-                self.forward_serial_console(component, offset, trailing_data);
+                self.forward_serial_console(
+                    component,
+                    offset,
+                    sp_trailing_data,
+                );
             }
         }
     }
@@ -765,9 +772,9 @@ impl Inner {
         &mut self,
         addr: SocketAddrV6,
         kind: RequestKind,
-        trailing_data: Option<&mut Cursor<Vec<u8>>>,
+        our_trailing_data: Option<&mut Cursor<Vec<u8>>>,
         incoming_buf: &mut [u8; gateway_messages::MAX_SERIALIZED_SIZE],
-    ) -> Result<(SocketAddrV6, ResponseKind)> {
+    ) -> Result<(SocketAddrV6, ResponseKind, Vec<u8>)> {
         // Build and serialize our request once.
         self.request_id += 1;
         let request = Request {
@@ -779,7 +786,7 @@ impl Inner {
         };
 
         let mut outgoing_buf = [0; gateway_messages::MAX_SERIALIZED_SIZE];
-        let n = match trailing_data {
+        let n = match our_trailing_data {
             Some(data) => {
                 let (n, written) =
                     gateway_messages::serialize_with_trailing_data(
@@ -832,7 +839,7 @@ impl Inner {
         request_id: u32,
         serialized_request: &[u8],
         incoming_buf: &mut [u8; gateway_messages::MAX_SERIALIZED_SIZE],
-    ) -> Result<Option<(SocketAddrV6, ResponseKind)>> {
+    ) -> Result<Option<(SocketAddrV6, ResponseKind, Vec<u8>)>> {
         // We consider an RPC attempt to be our attempt to contact the SP. It's
         // possible for the SP to respond and say it's busy; we shouldn't count
         // that as a failed UDP RPC attempt, so we loop within this "one
@@ -852,7 +859,7 @@ impl Inner {
                 Err(_elapsed) => return Ok(None),
             };
 
-            let (peer, response, trailing_data) = match result {
+            let (peer, response, sp_trailing_data) = match result {
                 Ok((peer, response, data)) => (peer, response, data),
                 Err(err) => {
                     warn!(
@@ -865,9 +872,6 @@ impl Inner {
 
             let result = match response.kind {
                 SpMessageKind::Response { request_id: response_id, result } => {
-                    if !trailing_data.is_empty() {
-                        warn!(self.log, "received unexpected trailing data with response (discarding)");
-                    }
                     if response_id == request_id {
                         result
                     } else {
@@ -883,7 +887,7 @@ impl Inner {
                     self.forward_serial_console(
                         component,
                         offset,
-                        trailing_data,
+                        sp_trailing_data,
                     );
                     continue;
                 }
@@ -896,7 +900,9 @@ impl Inner {
                     time::sleep(backoff_sleep).await;
                     continue;
                 }
-                other => return Ok(Some((peer, other?))),
+                other => {
+                    return Ok(Some((peer, other?, sp_trailing_data.to_vec())))
+                }
             }
         }
     }
@@ -956,7 +962,7 @@ impl Inner {
             ));
         }
 
-        let (_peer, response) = self
+        let (_peer, response, _data) = self
             .rpc_call(
                 sp_addr,
                 RequestKind::SerialConsoleAttach(component),
@@ -980,7 +986,7 @@ impl Inner {
         sp_addr: SocketAddrV6,
         incoming_buf: &mut [u8; gateway_messages::MAX_SERIALIZED_SIZE],
     ) -> Result<()> {
-        let (_peer, response) = self
+        let (_peer, response, _data) = self
             .rpc_call(
                 sp_addr,
                 RequestKind::SerialConsoleDetach,
@@ -1033,7 +1039,7 @@ async fn recv<'a>(
         }
     };
 
-    let (message, leftover) =
+    let (message, sp_trailing_data) =
         gateway_messages::deserialize::<SpMessage>(&incoming_buf[..n])
             .map_err(|err| SpCommunicationError::Deserialize { peer, err })?;
 
@@ -1043,14 +1049,7 @@ async fn recv<'a>(
         "message" => ?message,
     );
 
-    let trailing_data = if leftover.is_empty() {
-        &[]
-    } else {
-        sp_impl::unpack_trailing_data(leftover)
-            .map_err(|err| SpCommunicationError::Deserialize { peer, err })?
-    };
-
-    Ok((peer, message, trailing_data))
+    Ok((peer, message, sp_trailing_data))
 }
 
 fn sp_busy_policy() -> backoff::ExponentialBackoff {

--- a/gateway-sp-comms/src/single_sp/update.rs
+++ b/gateway-sp-comms/src/single_sp/update.rs
@@ -81,7 +81,7 @@ pub(super) async fn start_sp_update(
     )
     .await
     .result
-    .and_then(|(_peer, response)| {
+    .and_then(|(_peer, response, _data)| {
         response.expect_sp_update_prepare_ack().map_err(Into::into)
     })?;
 
@@ -253,7 +253,7 @@ pub(super) async fn start_component_update(
     )
     .await
     .result
-    .and_then(|(_peer, response)| {
+    .and_then(|(_peer, response, _data)| {
         response.expect_component_update_prepare_ack().map_err(Into::into)
     })?;
 
@@ -412,7 +412,7 @@ pub(super) async fn update_status(
     super::rpc(cmds_tx, RequestKind::UpdateStatus(component), None)
         .await
         .result
-        .and_then(|(_peer, response)| {
+        .and_then(|(_peer, response, _data)| {
             response.expect_update_status().map_err(Into::into)
         })
 }
@@ -464,7 +464,7 @@ async fn send_single_update_chunk(
     )
     .await;
 
-    result.and_then(|(_peer, response)| {
+    result.and_then(|(_peer, response, _data)| {
         response.expect_update_chunk_ack().map_err(Into::into)
     })?;
 


### PR DESCRIPTION
This allows us to fetch a full list of

```rust
pub struct SpDevice {
    pub device: String,
    pub description: String,
    pub num_measurement_channels: u32,
    pub presence: DevicePresence,
}
```

from an SP, where `device`/`description`/`presence` are analogous to what `humility validate` shows today, and `num_measurement_channels` indicates which devices can report measurements (what we currently call "sensors" but are in the process of renaming).

This PR includes one commit (280c52c) to _remove_ the assumption that any trailing data sent in the remainder of a packet is prefixed by a 2-byte length, since we're now sending TLV-packed data in this case. After discussion with @andrewjstone I don't think the link prefix is necessary in the two cases we were using it (update chunks and serial console data), since the length is already implicit in the amount of data contained in the packet.