### PR TITLE
Minor updates to device description fields based on MGS integration

### DIFF
--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -252,16 +252,17 @@ async fn main() -> Result<()> {
         Some(SpCommand::Inventory) => {
             let inventory = sp.inventory().await?;
             println!(
-                "{:<12} {:>10} {:<16} {:<}",
-                "STATUS", "MEAS.CHAN.", "DEVICE", "DESCRIPTION"
+                "{:<16} {:<12} {:<16} {:<}",
+                "COMPONENT", "STATUS", "DEVICE", "DESCRIPTION (CAPABILITIES)"
             );
             for d in inventory.devices {
                 println!(
-                    "{:<12} {:>10} {:<16} {:<}",
+                    "{:<16} {:<12} {:<16} {} ({:?})",
+                    d.component.as_str().unwrap_or("???"),
                     format!("{:?}", d.presence),
-                    d.num_measurement_channels,
                     d.device,
-                    d.description
+                    d.description,
+                    d.capabilities,
                 );
             }
         }

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -9,6 +9,7 @@ use crate::version;
 use crate::BadRequestReason;
 use crate::BulkIgnitionState;
 use crate::ComponentUpdatePrepare;
+use crate::DeviceCapabilities;
 use crate::DeviceDescriptionHeader;
 use crate::DeviceInventoryPage;
 use crate::DevicePresence;
@@ -45,18 +46,20 @@ pub struct SocketAddrV6 {
 /// Description of a device as reported as part of this SP's inventory.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct DeviceDescription<'a> {
+    pub component: SpComponent,
     pub device: &'a str,
     pub description: &'a str,
-    pub num_measurement_channels: u32,
+    pub capabilities: DeviceCapabilities,
     pub presence: DevicePresence,
 }
 
 impl From<DeviceDescription<'_>> for DeviceDescriptionHeader {
     fn from(dev: DeviceDescription<'_>) -> Self {
         Self {
+            component: dev.component,
             device_len: dev.device.len() as u32,
             description_len: dev.description.len() as u32,
-            num_measurement_channels: dev.num_measurement_channels,
+            capabilities: dev.capabilities,
             presence: dev.presence,
         }
     }

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -14,6 +14,7 @@ use backoff::backoff::Backoff;
 use gateway_messages::tlv;
 use gateway_messages::version;
 use gateway_messages::BulkIgnitionState;
+use gateway_messages::DeviceCapabilities;
 use gateway_messages::DeviceDescriptionHeader;
 use gateway_messages::DevicePresence;
 use gateway_messages::IgnitionCommand;
@@ -89,9 +90,10 @@ pub struct SpInventory {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SpDevice {
+    pub component: SpComponent,
     pub device: String,
     pub description: String,
-    pub num_measurement_channels: u32,
+    pub capabilities: DeviceCapabilities,
     pub presence: DevicePresence,
 }
 
@@ -466,9 +468,10 @@ fn decode_tlv_devices(
                     })?;
 
                 out.push(SpDevice {
+                    component: header.component,
                     device: device.to_string(),
                     description: description.to_string(),
-                    num_measurement_channels: header.num_measurement_channels,
+                    capabilities: header.capabilities,
                     presence: header.presence,
                 });
             }


### PR DESCRIPTION
1. Add an `SpComponent` that can be used for follow-up API calls related to each component
2. Replace `num_measurement_channels` with the more general `capabilities` bitmask.