### PR TITLE
Rework switch port config to allow specifying an interface

### DIFF
--- a/faux-mgs/Cargo.toml
+++ b/faux-mgs/Cargo.toml
@@ -7,7 +7,6 @@ license = "MPL-2.0"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }
-nix = { version = "0.25", default-features = false, features = ["net"] }
 slog = { version = "2.7", features = ["max_level_trace", "release_max_level_debug"] }
 slog-async = "2.6"
 slog-term = "2.9"

--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -174,17 +174,17 @@ async fn main() -> Result<()> {
         log.clone(),
     );
 
+    // Wait for `sp` to finish starting up.
+    sp.wait_for_startup_completion()
+        .await
+        .with_context(|| "SP communicator startup failed")?;
+
     match args.command {
         Command::Discover => {
             info!(log, "attempting SP discovery");
 
-            // Wait for `sp` to finish starting up.
-            sp.wait_for_startup_completion()
-                .await
-                .with_context(|| "SP communicator startup failed")?;
-
-            // `sp_addr_watch()` can only fail if startup fails, which we just
-            // checked; this is safe to unwrap.
+            // `sp_addr_watch()` can only fail if startup fails, which we waited
+            // for and checked above; this is safe to unwrap.
             let mut addr_watch = sp.sp_addr_watch().unwrap().clone();
 
             // "None" command indicates only discovery was requested; loop until

--- a/gateway-sp-comms/Cargo.toml
+++ b/gateway-sp-comms/Cargo.toml
@@ -7,6 +7,7 @@ license = "MPL-2.0"
 [dependencies]
 backoff = { version = "0.4.0", features = ["tokio"] }
 futures = "0.3.24"
+nix = { version = "0.25", default-features = false, features = ["net"] }
 once_cell = "1.15.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "2.0.1"

--- a/gateway-sp-comms/src/communicator.rs
+++ b/gateway-sp-comms/src/communicator.rs
@@ -5,8 +5,8 @@
 // Copyright 2022 Oxide Computer Company
 
 use crate::error::BadResponseType;
+use crate::error::ConfigError;
 use crate::error::Error;
-use crate::error::StartupError;
 use crate::management_switch::ManagementSwitch;
 use crate::management_switch::SwitchPort;
 use crate::single_sp::AttachedSerialConsole;
@@ -58,7 +58,7 @@ impl Communicator {
     pub async fn new(
         config: SwitchConfig,
         log: &Logger,
-    ) -> Result<Self, StartupError> {
+    ) -> Result<Self, ConfigError> {
         let log = log.new(o!("component" => "SpCommunicator"));
         let switch = ManagementSwitch::new(config, &log).await?;
 

--- a/gateway-sp-comms/src/lib.rs
+++ b/gateway-sp-comms/src/lib.rs
@@ -45,11 +45,11 @@ pub use timeout::Timeout;
 
 const DISCOVERY_MULTICAST_ADDR: Ipv6Addr =
     Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 1);
-const SP_MGS_PORT: u16 = 11111;
+const SP_PORT: u16 = 11111;
 
 /// Default address to discover an SP via UDP multicast.
 pub fn default_discovery_addr() -> SocketAddrV6 {
-    SocketAddrV6::new(DISCOVERY_MULTICAST_ADDR, SP_MGS_PORT, 0, 0)
+    SocketAddrV6::new(DISCOVERY_MULTICAST_ADDR, SP_PORT, 0, 0)
 }
 
 /// Default address to use when binding our local socket.

--- a/gateway-sp-comms/src/lib.rs
+++ b/gateway-sp-comms/src/lib.rs
@@ -18,6 +18,9 @@ mod management_switch;
 mod single_sp;
 mod timeout;
 
+use std::net::Ipv6Addr;
+use std::net::SocketAddrV6;
+
 pub use usdt::register_probes;
 
 pub mod error;
@@ -30,12 +33,30 @@ pub use management_switch::SpIdentifier;
 pub use management_switch::SpType;
 pub use management_switch::SwitchConfig;
 pub use management_switch::SwitchPortConfig;
+pub use management_switch::SwitchPortDescription;
 pub use single_sp::AttachedSerialConsole;
 pub use single_sp::AttachedSerialConsoleRecv;
 pub use single_sp::AttachedSerialConsoleSend;
 pub use single_sp::SingleSp;
 pub use single_sp::SpDevice;
 pub use single_sp::SpInventory;
-pub use single_sp::DISCOVERY_MULTICAST_ADDR;
 pub use timeout::Elapsed;
 pub use timeout::Timeout;
+
+const DISCOVERY_MULTICAST_ADDR: Ipv6Addr =
+    Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 1);
+const SP_MGS_PORT: u16 = 11111;
+
+/// Default address to discover an SP via UDP multicast.
+pub fn default_discovery_addr() -> SocketAddrV6 {
+    SocketAddrV6::new(DISCOVERY_MULTICAST_ADDR, SP_MGS_PORT, 0, 0)
+}
+
+/// Default address to use when binding our local socket.
+pub fn default_listen_addr() -> SocketAddrV6 {
+    // TODO: Currently the SP never tries to discover MGS, only MGS discovers
+    // SP, which means only SPs need to be listening on known ports. Can we bind
+    // the same port on all the vlan interfaces so in the future SPs could
+    // discover MGS if needed?
+    SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0)
+}

--- a/gateway-sp-comms/src/management_switch/location_map.rs
+++ b/gateway-sp-comms/src/management_switch/location_map.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
-/// Description of the network interface for a single switch port.
+/// Configuration of a single port of the management network switch.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct SwitchPortConfig {
     /// Address to bind our listening socket for this switch port.
@@ -48,7 +48,7 @@ pub struct SwitchPortConfig {
     pub interface: Option<String>,
 }
 
-/// Configuration of a single port of the management network switch.
+/// Description of the network interface for a single switch port.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct SwitchPortDescription {
     #[serde(flatten)]

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -151,6 +151,7 @@ impl SingleSp {
         Self { state, inner_task, log }
     }
 
+    /// Block until all our local setup (see [`SingleSp::new()`] is complete.
     pub async fn wait_for_startup_completion(
         &self,
     ) -> Result<(), StartupError> {
@@ -159,6 +160,11 @@ impl SingleSp {
 
     /// Retrieve the [`watch::Receiver`] for notifications of discovery of an
     /// SP's address.
+    ///
+    /// This function only returns an error if startup has failed; if startup
+    /// has succeeded, always returns `Ok(_)` even if no SP has been discovered
+    /// yet (in which case the returned receiver will be holding the value
+    /// `None`).
     pub fn sp_addr_watch(
         &self,
     ) -> Result<&watch::Receiver<Option<(SocketAddrV6, SpPort)>>, StartupError>

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -40,7 +40,6 @@ use slog::Logger;
 use std::io::Cursor;
 use std::io::Seek;
 use std::io::SeekFrom;
-use std::net::Ipv6Addr;
 use std::net::SocketAddr;
 use std::net::SocketAddrV6;
 use std::str;
@@ -59,9 +58,6 @@ mod update;
 use self::update::start_component_update;
 use self::update::start_sp_update;
 use self::update::update_status;
-
-pub const DISCOVERY_MULTICAST_ADDR: Ipv6Addr =
-    Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 1);
 
 // Once we've discovered an SP, continue to send discovery packets on this
 // interval to detect changes.
@@ -113,9 +109,7 @@ impl Drop for SingleSp {
 
 impl SingleSp {
     /// Construct a new `SingleSp` that will periodically attempt to discover an
-    /// SP reachable at `discovery_addr` (typically
-    /// [`DISCOVERY_MULTICAST_ADDR`], but possibly different in test /
-    /// development setups).
+    /// SP reachable at `discovery_addr`.
     pub fn new(
         socket: UdpSocket,
         discovery_addr: SocketAddrV6,

--- a/gateway-sp-comms/src/single_sp/startup.rs
+++ b/gateway-sp-comms/src/single_sp/startup.rs
@@ -1,0 +1,228 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//! Helper functionality for async startup of a `SingleSp`.
+
+use super::Inner;
+use super::InnerCommand;
+use crate::error::StartupError;
+use crate::SwitchPortConfig;
+use futures::Future;
+use gateway_messages::SpPort;
+use once_cell::sync::OnceCell;
+use slog::info;
+use slog::Logger;
+use std::net::SocketAddrV6;
+use std::time::Duration;
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc;
+use tokio::sync::watch;
+
+// States we can be in to allow immediate creation of a `SingleSp` even though
+// it can't immediately communicate on the management network.
+#[derive(Debug)]
+enum StartupState {
+    // We're waiting for our configured network interface to exist.
+    WaitingForInterface(String),
+    // We're waiting for the result of attempting to bind to our listening
+    // interface.
+    WaitingToBind(SocketAddrV6),
+    // Startup is complete (although not necessarily successful!).
+    //
+    // TODO We currently treat failure to bind a socket as a terminal error,
+    // expecting it to be indicative of a configuration problem we have no
+    // recourse to solve. Is that correct, or do we need some way of recovering
+    // and retrying the startup process?
+    Complete(Result<RunningState, StartupError>),
+}
+
+#[derive(Debug, Clone)]
+struct RunningState {
+    cmds_tx: mpsc::Sender<InnerCommand>,
+    sp_addr_rx: watch::Receiver<Option<(SocketAddrV6, SpPort)>>,
+}
+
+#[derive(Debug)]
+pub(super) struct State {
+    startup_rx: watch::Receiver<StartupState>,
+    complete: OnceCell<Result<RunningState, StartupError>>,
+}
+
+impl State {
+    pub(super) fn new(
+        config: SwitchPortConfig,
+        max_attempts_per_rpc: usize,
+        per_attempt_timeout: Duration,
+        log: Logger,
+    ) -> (Self, impl Future<Output = Option<Inner>>) {
+        let initial_state = if let Some(interface) = config.interface.clone() {
+            StartupState::WaitingForInterface(interface)
+        } else {
+            StartupState::WaitingToBind(config.listen_addr)
+        };
+
+        let (startup_tx, startup_rx) = watch::channel(initial_state);
+
+        let startup_fut = async move {
+            // If we've been given the name of an interface, wait for it to
+            // exist.
+            let scope_id = match config.interface.as_deref() {
+                Some(interface) => {
+                    wait_for_interface_scope_id(interface, &log).await
+                }
+                None => 0,
+            };
+
+            let mut listen_addr = config.listen_addr;
+            let mut discovery_addr = config.discovery_addr;
+            listen_addr.set_scope_id(scope_id);
+            discovery_addr.set_scope_id(scope_id);
+
+            // If we had to do an interface lookup, notify any waiters that
+            // we're transitioning to a new state.
+            if config.interface.is_some() {
+                startup_tx.send_modify(|s| {
+                    *s = StartupState::WaitingToBind(listen_addr)
+                });
+            }
+
+            // Attempt to bind; if this fails, we are misconfigured and will
+            // forever return errors from all of our methods.
+            let socket = match UdpSocket::bind(listen_addr).await {
+                Ok(socket) => socket,
+                Err(err) => {
+                    startup_tx.send_modify(|s| {
+                        *s = StartupState::Complete(Err(
+                            StartupError::UdpBind {
+                                addr: listen_addr,
+                                err: err.to_string(),
+                            },
+                        ));
+                    });
+                    return None;
+                }
+            };
+
+            // Binding succeeded; we have successfully started up and can
+            // now construct an `Inner` with which our parent `SingleSp` can
+            // communicate.
+            //
+            // SPs don't support pipelining, so any command we send to
+            // `Inner` that involves contacting an SP will effectively block
+            // until it completes. We use a more-or-less arbitrary chanel
+            // size of 8 here to allow (a) non-SP commands (e.g., detaching
+            // the serial console) and (b) a small number of enqueued SP
+            // commands to be submitted without blocking the caller.
+            let (cmds_tx, cmds_rx) = mpsc::channel(8);
+            let (sp_addr_tx, sp_addr_rx) = watch::channel(None);
+            startup_tx.send_modify(|s| {
+                *s = StartupState::Complete(Ok(RunningState {
+                    cmds_tx,
+                    sp_addr_rx,
+                }));
+            });
+
+            Some(Inner::new(
+                log,
+                socket,
+                sp_addr_tx,
+                discovery_addr,
+                max_attempts_per_rpc,
+                per_attempt_timeout,
+                cmds_rx,
+            ))
+        };
+
+        (Self { startup_rx, complete: OnceCell::new() }, startup_fut)
+    }
+
+    fn check_complete(&self) -> Result<&RunningState, StartupError> {
+        // Have we already completed? If so, we have our state saved in
+        // `self.complete`.
+        if let Some(result) = self.complete.get() {
+            return result.as_ref().map_err(Clone::clone);
+        }
+
+        match &*self.startup_rx.borrow() {
+            StartupState::WaitingForInterface(iface) => {
+                Err(StartupError::WaitingForInterface(iface.clone()))
+            }
+            StartupState::WaitingToBind(addr) => {
+                Err(StartupError::WaitingToBind(*addr))
+            }
+            StartupState::Complete(result) => self
+                .complete
+                .get_or_init(|| result.clone())
+                .as_ref()
+                .map_err(Clone::clone),
+        }
+    }
+
+    pub(super) async fn wait_for_startup_completion(
+        &self,
+    ) -> Result<(), StartupError> {
+        let mut startup_rx = self.startup_rx.clone();
+        loop {
+            match &*startup_rx.borrow_and_update() {
+                StartupState::WaitingForInterface(_)
+                | StartupState::WaitingToBind(_) => {}
+                StartupState::Complete(result) => {
+                    return result.as_ref().map(|_| ()).map_err(Clone::clone)
+                }
+            }
+
+            // `startup_tx` is never dropped before it sets the state to
+            // `Complete(_)`, so we can unwrap here. This is not clear from the
+            // `watch::Receiver` docs, which claims this fails if the sender has
+            // been dropped: this actually fails if the sender has been dropped
+            // _without changing the value_.
+            startup_rx.changed().await.unwrap();
+        }
+    }
+
+    pub(super) fn cmds_tx(
+        &self,
+    ) -> Result<&mpsc::Sender<InnerCommand>, StartupError> {
+        self.check_complete().map(|state| &state.cmds_tx)
+    }
+
+    pub(super) fn sp_addr_rx(
+        &self,
+    ) -> Result<&watch::Receiver<Option<(SocketAddrV6, SpPort)>>, StartupError>
+    {
+        self.check_complete().map(|state| &state.sp_addr_rx)
+    }
+}
+
+// Helper wrapper around `if_nametoindex()` that retries indefinitely if the
+// lookup fails.
+async fn wait_for_interface_scope_id(interface: &str, log: &Logger) -> u32 {
+    // We're going to constantly spin waiting for `config.interface` to exist;
+    // how long do we sleep between attempts?
+    //
+    // TODO replace with exponential backoff with a low-ish cap?
+    const SLEEP_BETWEEN_RETRY: Duration = Duration::from_secs(5);
+
+    loop {
+        match nix::net::if_::if_nametoindex(interface) {
+            Ok(id) => return id,
+            Err(err) => {
+                // TODO This assumes something else is responsible for
+                // creating the interface we're supposed to use; if it needs
+                // to be us (or if we need to do extra work to use it) we
+                // need to do more here.
+                info!(
+                    log,
+                    "if_nametoindex failed; will retry after {:?}",
+                    SLEEP_BETWEEN_RETRY;
+                    "interface" => interface,
+                    "err" => %err,
+                );
+                tokio::time::sleep(SLEEP_BETWEEN_RETRY).await;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Each management network is now configured by the triple `(listen_addr, discovery_addr, interface)`, where `listen_addr` and `discovery_addr` are expected to be identical for all ports (but may not be in tests where we're simulating a management network) and `interface` is expected to be specific to each port (but is optional, again to support simulating a management network). If an `interface` is provided, the `SingleSp` responsible for communication on that port will wait indefinitely for the interface to exist (checked via libc's `if_nametoindex()` function).

This PR also reworks how `SingleSp`s are initialized (and therefore how MGS startup works). Creating a new `SingleSp` can now only fail if there is an obvious misconfiguration in the toml file; it returns even before a UDP socket is bound, since it may need to wait an unknown amount of time for its `interface` to appear. Any method calls made on that `SingleSp` will fail while we're in the "starting up" phase. `SingleSp::wait_for_startup_completion()` provides a way for a caller to block until that startup is done, but MGS proper is _not_ expected to call that method - it only exists for use by `faux-mgs`.