### PR TITLE
Add messages to get/set sled startup options

### DIFF
--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -86,8 +86,8 @@ enum Command {
     /// Ask SP for its current state.
     State,
 
-    /// Set startup options on an SP.
-    SetStartupOptions { options: u64 },
+    /// Get or set startup options on an SP.
+    StartupOptions { options: Option<u64> },
 
     /// Ask SP for its inventory.
     Inventory,
@@ -226,12 +226,18 @@ async fn main() -> Result<()> {
         Command::State => {
             info!(log, "{:?}", sp.state().await?);
         }
-        Command::SetStartupOptions { options } => {
-            let options =
-                StartupOptions::from_bits(options).with_context(|| {
-                    format!("invalid startup options bits: {options:#x}")
-                })?;
-            sp.set_startup_options(options).await?;
+        Command::StartupOptions { options } => {
+            if let Some(options) = options {
+                let options =
+                    StartupOptions::from_bits(options).with_context(|| {
+                        format!("invalid startup options bits: {options:#x}")
+                    })?;
+                sp.set_startup_options(options).await?;
+                println!("successfully set startup options to {options:?}");
+            } else {
+                let options = sp.get_startup_options().await?;
+                println!("startup options: {options:?}");
+            }
         }
         Command::Inventory => {
             let inventory = sp.inventory().await?;

--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -12,6 +12,7 @@ use clap::Parser;
 use clap::Subcommand;
 use gateway_messages::PowerState;
 use gateway_messages::SpComponent;
+use gateway_messages::StartupOptions;
 use gateway_messages::UpdateId;
 use gateway_messages::UpdateStatus;
 use gateway_sp_comms::SingleSp;
@@ -84,6 +85,9 @@ enum Command {
 
     /// Ask SP for its current state.
     State,
+
+    /// Set startup options on an SP.
+    SetStartupOptions { options: u64 },
 
     /// Ask SP for its inventory.
     Inventory,
@@ -221,6 +225,13 @@ async fn main() -> Result<()> {
         }
         Command::State => {
             info!(log, "{:?}", sp.state().await?);
+        }
+        Command::SetStartupOptions { options } => {
+            let options =
+                StartupOptions::from_bits(options).with_context(|| {
+                    format!("invalid startup options bits: {options:#x}")
+                })?;
+            sp.set_startup_options(options).await?;
         }
         Command::Inventory => {
             let inventory = sp.inventory().await?;

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -51,6 +51,7 @@ pub enum MgsRequest {
     Inventory {
         device_index: u32,
     },
+    SetStartupOptions(StartupOptions),
 }
 
 #[derive(
@@ -124,4 +125,17 @@ pub struct UpdateChunk {
     pub id: UpdateId,
     /// Offset in bytes of this chunk from the beginning of the update data.
     pub offset: u32,
+}
+
+bitflags::bitflags! {
+    #[derive(Serialize, Deserialize, SerializedSize)]
+    #[repr(transparent)]
+    pub struct StartupOptions: u64 {
+        const PHASE2_RECOVERY_MODE = 1 << 0;
+        const DEBUG_KBM = 1 << 1;
+        const DEBUG_BOOTRD = 1 << 2;
+        const DEBUG_PROM = 1 << 3;
+        const DEBUG_KMDB = 1 << 4;
+        const DEBUG_KMDB_BOOT = 1 << 5;
+    }
 }

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -51,6 +51,7 @@ pub enum MgsRequest {
     Inventory {
         device_index: u32,
     },
+    GetStartupOptions,
     SetStartupOptions(StartupOptions),
 }
 

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -204,6 +204,12 @@ pub trait SpHandler {
     /// greater than or equal to the value returned by `num_devices()`).
     fn device_description(&mut self, index: u32) -> DeviceDescription<'_>;
 
+    fn get_startup_options(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+    ) -> Result<StartupOptions, SpError>;
+
     fn set_startup_options(
         &mut self,
         sender: SocketAddrV6,
@@ -563,6 +569,9 @@ fn handle_mgs_request<H: SpHandler>(
                 total_devices,
             }))
         }
+        MgsRequest::GetStartupOptions => handler
+            .get_startup_options(sender, port)
+            .map(SpResponse::StartupOptions),
         MgsRequest::SetStartupOptions(startup_options) => handler
             .set_startup_options(sender, port, startup_options)
             .map(|()| SpResponse::SetStartupOptionsAck),
@@ -746,6 +755,23 @@ mod tests {
         }
 
         fn device_description(&mut self, _index: u32) -> DeviceDescription<'_> {
+            unimplemented!()
+        }
+
+        fn get_startup_options(
+            &mut self,
+            _sender: SocketAddrV6,
+            _port: SpPort,
+        ) -> Result<StartupOptions, SpError> {
+            unimplemented!()
+        }
+
+        fn set_startup_options(
+            &mut self,
+            _sender: SocketAddrV6,
+            _port: SpPort,
+            _startup_options: StartupOptions,
+        ) -> Result<(), SpError> {
             unimplemented!()
         }
 

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -30,6 +30,7 @@ use crate::SpPort;
 use crate::SpResponse;
 use crate::SpState;
 use crate::SpUpdatePrepare;
+use crate::StartupOptions;
 use crate::UpdateChunk;
 use crate::UpdateId;
 use crate::UpdateStatus;
@@ -202,6 +203,13 @@ pub trait SpHandler {
     /// Implementors are allowed to panic if `index` is not in range (i.e., is
     /// greater than or equal to the value returned by `num_devices()`).
     fn device_description(&mut self, index: u32) -> DeviceDescription<'_>;
+
+    fn set_startup_options(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        startup_options: StartupOptions,
+    ) -> Result<(), SpError>;
 
     fn mgs_response_error(
         &mut self,
@@ -555,6 +563,9 @@ fn handle_mgs_request<H: SpHandler>(
                 total_devices,
             }))
         }
+        MgsRequest::SetStartupOptions(startup_options) => handler
+            .set_startup_options(sender, port, startup_options)
+            .map(|()| SpResponse::SetStartupOptionsAck),
     };
 
     let response = match result {

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -8,6 +8,7 @@ use crate::tlv;
 use crate::BadRequestReason;
 use crate::PowerState;
 use crate::SpComponent;
+use crate::StartupOptions;
 use crate::UpdateId;
 use bitflags::bitflags;
 use core::fmt;
@@ -68,6 +69,7 @@ pub enum SpResponse {
     /// descriptions. See TODO FIXME for details.
     Inventory(DeviceInventoryPage),
     Error(SpError),
+    StartupOptions(StartupOptions),
     SetStartupOptionsAck,
 }
 

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -68,6 +68,7 @@ pub enum SpResponse {
     /// descriptions. See TODO FIXME for details.
     Inventory(DeviceInventoryPage),
     Error(SpError),
+    SetStartupOptionsAck,
 }
 
 #[derive(

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -287,6 +287,18 @@ impl SingleSp {
         Ok(SpInventory { devices })
     }
 
+    /// Get the current startup options of the target SP.
+    ///
+    /// Startup options are only meaningful for sleds and will only take effect
+    /// the next time the sled starts up.
+    pub async fn get_startup_options(&self) -> Result<StartupOptions> {
+        self.rpc(MgsRequest::GetStartupOptions).await.and_then(
+            |(_peer, response, _data)| {
+                response.expect_startup_options().map_err(Into::into)
+            },
+        )
+    }
+
     /// Set startup options on the target SP.
     ///
     /// Startup options are only meaningful for sleds and will only take effect

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -35,6 +35,7 @@ use gateway_messages::SpPort;
 use gateway_messages::SpRequest;
 use gateway_messages::SpResponse;
 use gateway_messages::SpState;
+use gateway_messages::StartupOptions;
 use gateway_messages::UpdateStatus;
 use slog::debug;
 use slog::error;
@@ -284,6 +285,21 @@ impl SingleSp {
         }
 
         Ok(SpInventory { devices })
+    }
+
+    /// Set startup options on the target SP.
+    ///
+    /// Startup options are only meaningful for sleds and will only take effect
+    /// the next time the sled starts up.
+    pub async fn set_startup_options(
+        &self,
+        startup_options: StartupOptions,
+    ) -> Result<()> {
+        self.rpc(MgsRequest::SetStartupOptions(startup_options)).await.and_then(
+            |(_peer, response, _data)| {
+                response.expect_set_startup_options_ack().map_err(Into::into)
+            },
+        )
     }
 
     /// Update a component of the SP (or the SP itself!).

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -65,6 +65,9 @@ pub(crate) trait SpResponseExt {
     fn expect_inventory(
         self,
     ) -> Result<DeviceInventoryPage, SpCommunicationError>;
+
+    fn expect_set_startup_options_ack(self)
+        -> Result<(), SpCommunicationError>;
 }
 
 impl SpResponseExt for SpResponse {
@@ -102,6 +105,9 @@ impl SpResponseExt for SpResponse {
             Self::ResetPrepareAck => response_kind_names::RESET_PREPARE_ACK,
             Self::Inventory(_) => response_kind_names::INVENTORY,
             Self::Error(_) => response_kind_names::ERROR,
+            Self::SetStartupOptionsAck => {
+                response_kind_names::SET_STARTUP_OPTIONS_ACK
+            }
         }
     }
 
@@ -309,6 +315,19 @@ impl SpResponseExt for SpResponse {
             }),
         }
     }
+
+    fn expect_set_startup_options_ack(
+        self,
+    ) -> Result<(), SpCommunicationError> {
+        match self {
+            Self::SetStartupOptionsAck => Ok(()),
+            Self::Error(err) => Err(SpCommunicationError::SpError(err)),
+            other => Err(SpCommunicationError::BadResponseType {
+                expected: response_kind_names::SET_STARTUP_OPTIONS_ACK,
+                got: other.name(),
+            }),
+        }
+    }
 }
 
 mod response_kind_names {
@@ -334,4 +353,5 @@ mod response_kind_names {
     pub(super) const RESET_PREPARE_ACK: &str = "reset_prepare_ack";
     pub(super) const INVENTORY: &str = "inventory";
     pub(super) const ERROR: &str = "error";
+    pub(super) const SET_STARTUP_OPTIONS_ACK: &str = "set_startup_options_ack";
 }

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -10,6 +10,7 @@ use gateway_messages::IgnitionState;
 use gateway_messages::PowerState;
 use gateway_messages::SpResponse;
 use gateway_messages::SpState;
+use gateway_messages::StartupOptions;
 use gateway_messages::UpdateStatus;
 
 // When we send a request we expect a specific kind of response; the boilerplate
@@ -66,6 +67,10 @@ pub(crate) trait SpResponseExt {
         self,
     ) -> Result<DeviceInventoryPage, SpCommunicationError>;
 
+    fn expect_startup_options(
+        self,
+    ) -> Result<StartupOptions, SpCommunicationError>;
+
     fn expect_set_startup_options_ack(self)
         -> Result<(), SpCommunicationError>;
 }
@@ -105,6 +110,7 @@ impl SpResponseExt for SpResponse {
             Self::ResetPrepareAck => response_kind_names::RESET_PREPARE_ACK,
             Self::Inventory(_) => response_kind_names::INVENTORY,
             Self::Error(_) => response_kind_names::ERROR,
+            Self::StartupOptions(_) => response_kind_names::STARTUP_OPTIONS,
             Self::SetStartupOptionsAck => {
                 response_kind_names::SET_STARTUP_OPTIONS_ACK
             }
@@ -316,6 +322,19 @@ impl SpResponseExt for SpResponse {
         }
     }
 
+    fn expect_startup_options(
+        self,
+    ) -> Result<StartupOptions, SpCommunicationError> {
+        match self {
+            Self::StartupOptions(options) => Ok(options),
+            Self::Error(err) => Err(SpCommunicationError::SpError(err)),
+            other => Err(SpCommunicationError::BadResponseType {
+                expected: response_kind_names::STARTUP_OPTIONS,
+                got: other.name(),
+            }),
+        }
+    }
+
     fn expect_set_startup_options_ack(
         self,
     ) -> Result<(), SpCommunicationError> {
@@ -353,5 +372,6 @@ mod response_kind_names {
     pub(super) const RESET_PREPARE_ACK: &str = "reset_prepare_ack";
     pub(super) const INVENTORY: &str = "inventory";
     pub(super) const ERROR: &str = "error";
+    pub(super) const STARTUP_OPTIONS: &str = "startup_options";
     pub(super) const SET_STARTUP_OPTIONS_ACK: &str = "set_startup_options_ack";
 }


### PR DESCRIPTION
`StartupOptions` is a bitflags struct that is copy/pasted from RFD 316 and the host/SP uart protocol. I _think_ it's reasonable for `gateway-messages` to include its own definitely (and require the SP to translate between the two structs) instead of trying to make `gateway-messages` depend on the host/SP messages crate or vice versa, but I could be talked out of it.