### PR TITLE
Add `ComponentDetails`, initially including VSC7448 port status

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,7 @@ on: [ push, pull_request ]
 
 jobs:
   check-style:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: Report cargo version
@@ -18,7 +18,7 @@ jobs:
         run: cargo fmt -- --check
 
   clippy-lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: Report cargo version
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-12]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: Report cargo version

--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -92,6 +92,9 @@ enum Command {
     /// Ask SP for its inventory.
     Inventory,
 
+    /// Ask SP for details of a component.
+    ComponentDetails { component: String },
+
     /// Attach to the SP's USART.
     UsartAttach {
         /// Put the local terminal in raw mode.
@@ -254,6 +257,16 @@ async fn main() -> Result<()> {
                     d.description,
                     d.capabilities,
                 );
+            }
+        }
+        Command::ComponentDetails { component } => {
+            let sp_component = SpComponent::try_from(component.as_str())
+                .map_err(|_| {
+                    anyhow!("invalid component name: {}", component)
+                })?;
+            let details = sp.component_details(sp_component).await?;
+            for entry in details.entries {
+                println!("{entry:?}");
             }
         }
         Command::UsartAttach { raw, stdin_buffer_time_millis } => {

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -137,6 +137,9 @@ impl SpComponent {
     /// The host CPU boot flash.
     pub const HOST_CPU_BOOT_FLASH: Self = Self { id: *b"host-boot-flash\0" };
 
+    /// The sidecar VSC7448 switch.
+    pub const VSC7448: Self = Self { id: *b"vsc7448\0\0\0\0\0\0\0\0\0" };
+
     /// Prefix for devices that are identified generically by index (e.g.,
     /// `dev-17`).
     pub const GENERIC_DEVICE_PREFIX: &'static str = "dev-";

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -53,6 +53,12 @@ pub enum MgsRequest {
     },
     GetStartupOptions,
     SetStartupOptions(StartupOptions),
+    /// Get detailed status information for a component, starting with `offset`
+    /// if the component has multiple status information items.
+    ComponentDetails {
+        component: SpComponent,
+        offset: u32,
+    },
 }
 
 #[derive(

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -11,7 +11,6 @@ use crate::BulkIgnitionState;
 use crate::ComponentUpdatePrepare;
 use crate::DeviceCapabilities;
 use crate::DeviceDescriptionHeader;
-use crate::DeviceInventoryPage;
 use crate::DevicePresence;
 use crate::DiscoverResponse;
 use crate::Header;
@@ -31,6 +30,7 @@ use crate::SpResponse;
 use crate::SpState;
 use crate::SpUpdatePrepare;
 use crate::StartupOptions;
+use crate::TlvPage;
 use crate::UpdateChunk;
 use crate::UpdateId;
 use crate::UpdateStatus;
@@ -560,9 +560,9 @@ fn handle_mgs_request<H: SpHandler>(
                     device_index,
                     total_devices,
                 });
-            Ok(SpResponse::Inventory(DeviceInventoryPage {
-                device_index,
-                total_devices,
+            Ok(SpResponse::Inventory(TlvPage {
+                offset: device_index,
+                total: total_devices,
             }))
         }
         MgsRequest::GetStartupOptions => handler

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -196,7 +196,7 @@ pub struct TlvPage {
 /// Note that `ComponentDetails` itself does not implement the relevant serde
 /// serialization traits; it only serves as an organizing collection of the
 /// possible types contained in a component details message. Each TLV-encoded
-/// struct corresponds with one of these cases.
+/// struct corresponds to one of these cases.
 #[derive(Debug, Clone, Copy)]
 pub enum ComponentDetails {
     PortStatus(Result<PortStatus, PortStatusError>),

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -65,9 +65,9 @@ pub enum SpResponse {
     // There is intentionally no `ResetTriggerAck` response; the expected
     // "response" to `ResetTrigger` is an SP reset, which won't allow for
     // acks to be sent.
-    /// An `Inventory` response is followed by a TLV-encoded set of device
-    /// descriptions. See TODO FIXME for details.
-    Inventory(DeviceInventoryPage),
+    /// An `Inventory` response is followed by a TLV-encoded set of
+    /// [`DeviceDescriptionHeader`]s.
+    Inventory(TlvPage),
     Error(SpError),
     StartupOptions(StartupOptions),
     SetStartupOptionsAck,
@@ -168,18 +168,19 @@ pub struct SpState {
     pub version: u32,
 }
 
-/// Metadata describing the set of device descriptions present in this response.
+/// Metadata describing a single page (out of a larger list) of TLV-encoded
+/// structures returned by the SP.
 ///
-/// Followed by trailing data containing a sequence of [`tlv`]-encoded
-/// [`DeviceDescriptionHeader`]s and their associated data.
+/// Always followed by trailing data containing a sequence of [`tlv`]-encoded
+/// structures (e.g., [`DeviceDescriptionHeader`], [`PortStatus`]).
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, SerializedSize,
 )]
-pub struct DeviceInventoryPage {
-    /// First device index present in this response.
-    pub device_index: u32,
-    /// Total number of devices present on the SP.
-    pub total_devices: u32,
+pub struct TlvPage {
+    /// First encoded structure present in this packet.
+    pub offset: u32,
+    /// Total number of structures in this data set.
+    pub total: u32,
 }
 
 /// Header for the description of a single device.

--- a/gateway-messages/src/sp_to_mgs/vsc7448_port_status.rs
+++ b/gateway-messages/src/sp_to_mgs/vsc7448_port_status.rs
@@ -1,0 +1,118 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Types for sidecar SP reporting VSC7448 port status.
+
+use crate::tlv;
+use hubpack::SerializedSize;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, SerializedSize)]
+pub struct PortStatusError {
+    pub port: u32,
+    pub code: PortStatusErrorCode,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, SerializedSize)]
+pub enum PortStatusErrorCode {
+    Unconfigured,
+    Other(u32),
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, SerializedSize)]
+pub struct PortStatus {
+    pub port: u32,
+    pub cfg: PortConfig,
+    pub link_status: LinkStatus,
+    pub phy_status: Option<PhyStatus>,
+    pub counters: PortCounters,
+}
+
+impl PortStatus {
+    pub const TAG: tlv::Tag = tlv::Tag(*b"VSC0");
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, SerializedSize)]
+pub struct PortConfig {
+    pub mode: PortMode,
+    pub dev: (PortDev, u8),
+    pub serdes: (PortSerdes, u8),
+}
+
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedSize,
+)]
+pub enum PortDev {
+    Dev1g,
+    Dev2g5,
+    Dev10g,
+}
+
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedSize,
+)]
+pub enum PortSerdes {
+    Serdes1g,
+    Serdes6g,
+    Serdes10g,
+}
+
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedSize,
+)]
+pub enum Speed {
+    Speed100M,
+    Speed1G,
+    Speed10G,
+}
+
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedSize,
+)]
+pub enum PortMode {
+    Sfi,
+    BaseKr,
+    Sgmii(Speed),
+    Qsgmii(Speed),
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, SerializedSize)]
+pub struct PacketCount {
+    pub multicast: u32,
+    pub unicast: u32,
+    pub broadcast: u32,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, SerializedSize)]
+pub struct PortCounters {
+    pub rx: PacketCount,
+    pub tx: PacketCount,
+}
+
+#[derive(
+    Copy, Clone, Debug, Serialize, Deserialize, SerializedSize, Eq, PartialEq,
+)]
+pub enum LinkStatus {
+    Error,
+    Down,
+    Up,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, SerializedSize)]
+pub struct PhyStatus {
+    pub ty: PhyType,
+    pub mac_link_up: LinkStatus,
+    pub media_link_up: LinkStatus,
+}
+
+#[derive(
+    Copy, Clone, Debug, Serialize, Deserialize, SerializedSize, Eq, PartialEq,
+)]
+pub enum PhyType {
+    Vsc8504,
+    Vsc8522,
+    Vsc8552,
+    Vsc8562,
+}

--- a/gateway-messages/src/tlv.rs
+++ b/gateway-messages/src/tlv.rs
@@ -5,6 +5,7 @@
 //! Extremely simple / minimal implementation of tag/length/value encoding,
 //! using 4-byte tags and lengths.
 
+use core::fmt;
 use core::iter;
 use core::mem;
 use zerocopy::byteorder::LittleEndian;
@@ -27,6 +28,19 @@ pub enum DecodeError {
     /// The `length` field requires more data than is remaining in the buffer.
     LengthTooLong,
 }
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            DecodeError::BufferTooSmall => "buffer too small",
+            DecodeError::LengthTooLong => "length too long",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for DecodeError {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, AsBytes, FromBytes)]
 #[repr(C)]

--- a/gateway-sp-comms/src/error.rs
+++ b/gateway-sp-comms/src/error.rs
@@ -5,6 +5,7 @@
 // Copyright 2022 Oxide Computer Company
 
 use crate::SpIdentifier;
+use gateway_messages::tlv;
 use gateway_messages::SpError;
 use std::io;
 use std::net::Ipv6Addr;
@@ -54,12 +55,14 @@ pub enum SpCommunicationError {
     SpError(#[from] SpError),
     #[error("Bogus serial console state; detach and reattach")]
     BogusSerialConsoleState,
-    #[error("SP claimed more inventory devices than we can accept")]
-    InventoryTooLarge,
-    #[error("Invalid inventory pagination state")]
-    InvalidInventoryPagination,
     #[error("Protocol version mismatch: SP version {sp}, MGS version {mgs}")]
     VersionMismatch { sp: u32, mgs: u32 },
+    #[error("failed to deserialize TLV value for tag {tag:?}: {err}")]
+    TlvDeserialize { tag: tlv::Tag, err: gateway_messages::HubpackError },
+    #[error("failed to decode TLV triple: {0}")]
+    TlvDecode(#[from] tlv::DecodeError),
+    #[error("invalid TLV pagination: {reason}")]
+    TlvPagination { reason: &'static str },
 }
 
 #[derive(Debug, Error)]

--- a/gateway-sp-comms/src/lib.rs
+++ b/gateway-sp-comms/src/lib.rs
@@ -28,6 +28,7 @@ pub mod error;
 
 pub use communicator::Communicator;
 pub use communicator::FuturesUnorderedImpl;
+pub use gateway_messages;
 pub use management_switch::LocationConfig;
 pub use management_switch::LocationDeterminationConfig;
 pub use management_switch::SpIdentifier;

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -16,6 +16,8 @@ use async_trait::async_trait;
 use backoff::backoff::Backoff;
 use gateway_messages::tlv;
 use gateway_messages::version;
+use gateway_messages::vsc7448_port_status::PortStatus;
+use gateway_messages::vsc7448_port_status::PortStatusError;
 use gateway_messages::BulkIgnitionState;
 use gateway_messages::DeviceCapabilities;
 use gateway_messages::DeviceDescriptionHeader;

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -31,8 +31,6 @@ use gateway_messages::MessageKind;
 use gateway_messages::MgsError;
 use gateway_messages::MgsRequest;
 use gateway_messages::MgsResponse;
-use gateway_messages::PortStatus;
-use gateway_messages::PortStatusError;
 use gateway_messages::PowerState;
 use gateway_messages::SpComponent;
 use gateway_messages::SpError;

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -259,21 +259,21 @@ impl SingleSp {
             // page we asked for, and is the total_devices correct? If this is
             // the first page, "correct" just means "reasonable"; if this is the
             // second or later page, it should match every other page.
-            if page.device_index != device_index {
+            if page.offset != device_index {
                 return Err(SpCommunicationError::InvalidInventoryPagination);
             }
             let total_devices = if let Some(n) = page0_total_devices {
-                if n != page.total_devices as usize {
+                if n != page.total as usize {
                     return Err(
                         SpCommunicationError::InvalidInventoryPagination,
                     );
                 }
                 n
             } else {
-                if page.total_devices > INVENTORY_TOTAL_DEVICE_DOS_LIMIT {
+                if page.offset > INVENTORY_TOTAL_DEVICE_DOS_LIMIT {
                     return Err(SpCommunicationError::InventoryTooLarge);
                 }
-                let n = page.total_devices as usize;
+                let n = page.total as usize;
                 devices.reserve_exact(n);
                 page0_total_devices = Some(n);
                 n

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -4,13 +4,13 @@
 
 use crate::error::SpCommunicationError;
 use gateway_messages::BulkIgnitionState;
-use gateway_messages::DeviceInventoryPage;
 use gateway_messages::DiscoverResponse;
 use gateway_messages::IgnitionState;
 use gateway_messages::PowerState;
 use gateway_messages::SpResponse;
 use gateway_messages::SpState;
 use gateway_messages::StartupOptions;
+use gateway_messages::TlvPage;
 use gateway_messages::UpdateStatus;
 
 // When we send a request we expect a specific kind of response; the boilerplate
@@ -63,9 +63,7 @@ pub(crate) trait SpResponseExt {
 
     fn expect_sys_reset_prepare_ack(self) -> Result<(), SpCommunicationError>;
 
-    fn expect_inventory(
-        self,
-    ) -> Result<DeviceInventoryPage, SpCommunicationError>;
+    fn expect_inventory(self) -> Result<TlvPage, SpCommunicationError>;
 
     fn expect_startup_options(
         self,
@@ -309,9 +307,7 @@ impl SpResponseExt for SpResponse {
         }
     }
 
-    fn expect_inventory(
-        self,
-    ) -> Result<DeviceInventoryPage, SpCommunicationError> {
+    fn expect_inventory(self) -> Result<TlvPage, SpCommunicationError> {
         match self {
             Self::Inventory(page) => Ok(page),
             Self::Error(err) => Err(SpCommunicationError::SpError(err)),

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -71,6 +71,8 @@ pub(crate) trait SpResponseExt {
 
     fn expect_set_startup_options_ack(self)
         -> Result<(), SpCommunicationError>;
+
+    fn expect_component_details(self) -> Result<TlvPage, SpCommunicationError>;
 }
 
 impl SpResponseExt for SpResponse {
@@ -112,6 +114,7 @@ impl SpResponseExt for SpResponse {
             Self::SetStartupOptionsAck => {
                 response_kind_names::SET_STARTUP_OPTIONS_ACK
             }
+            Self::ComponentDetails(_) => response_kind_names::COMPONENT_DETAILS,
         }
     }
 
@@ -343,6 +346,17 @@ impl SpResponseExt for SpResponse {
             }),
         }
     }
+
+    fn expect_component_details(self) -> Result<TlvPage, SpCommunicationError> {
+        match self {
+            Self::ComponentDetails(page) => Ok(page),
+            Self::Error(err) => Err(SpCommunicationError::SpError(err)),
+            other => Err(SpCommunicationError::BadResponseType {
+                expected: response_kind_names::COMPONENT_DETAILS,
+                got: other.name(),
+            }),
+        }
+    }
 }
 
 mod response_kind_names {
@@ -370,4 +384,5 @@ mod response_kind_names {
     pub(super) const ERROR: &str = "error";
     pub(super) const STARTUP_OPTIONS: &str = "startup_options";
     pub(super) const SET_STARTUP_OPTIONS_ACK: &str = "set_startup_options_ack";
+    pub(super) const COMPONENT_DETAILS: &str = "component_details";
 }


### PR DESCRIPTION
We already have the inventory overview that returns a list of components and a bitmask indicating capabilities, with the intent to add an additional followup message to get the current details/status of specific components that support that. This PR adds the `ComponentDetails` messages, whose payload include a set of TLV-wrapped hubpack-encoded structs (just like inventory); the only kind of component detail included in this PR is the VSC7448 `PortStatus`. When asking a live sidecar SP for the details of its `vsc7448` component, it returns a list of all 53 ports (split across three UDP packets):

```
PortStatus(Ok(PortStatus { port: 0, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev1g, 0), serdes: (Serdes1g, 1) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCount
 { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 1, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev1g, 1), serdes: (Serdes1g, 2) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCount
 { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 2, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev1g, 2), serdes: (Serdes1g, 3) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCount
 { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 3, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev1g, 3), serdes: (Serdes1g, 4) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCount
 { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 4, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev1g, 4), serdes: (Serdes1g, 5) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCount
 { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 5, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev1g, 5), serdes: (Serdes1g, 6) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCount
 { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 6, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev1g, 6), serdes: (Serdes1g, 7) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCount
 { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 7, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev1g, 7), serdes: (Serdes1g, 8) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCount
 { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 8, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 0), serdes: (Serdes6g, 0) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCoun
t { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 9, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 1), serdes: (Serdes6g, 1) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCoun
t { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 10, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 2), serdes: (Serdes6g, 2) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCou
nt { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 11, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 3), serdes: (Serdes6g, 3) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCou
nt { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 12, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 4), serdes: (Serdes6g, 4) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCou
nt { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 13, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 5), serdes: (Serdes6g, 5) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCou
nt { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 14, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 6), serdes: (Serdes6g, 6) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCou
nt { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 15, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 7), serdes: (Serdes6g, 7) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCou
nt { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 16, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 8), serdes: (Serdes6g, 8) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCou
nt { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 17, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 9), serdes: (Serdes6g, 9) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCou
nt { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 18, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 10), serdes: (Serdes6g, 10) }, link_status: Up, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 10, unicast: 0, broadcast: 0 }, tx: PacketCo
unt { multicast: 22, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 19, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 11), serdes: (Serdes6g, 11) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketC
ount { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 20, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 12), serdes: (Serdes6g, 12) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketC
ount { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 21, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 13), serdes: (Serdes6g, 13) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketC
ount { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Err(PortStatusError { port: 22, code: Unconfigured }))
PortStatus(Err(PortStatusError { port: 23, code: Unconfigured }))
PortStatus(Ok(PortStatus { port: 24, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 16), serdes: (Serdes6g, 16) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketC
ount { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 25, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 17), serdes: (Serdes6g, 17) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketC
ount { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 26, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 18), serdes: (Serdes6g, 18) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketC
ount { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 27, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 19), serdes: (Serdes6g, 19) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketC
ount { multicast: 32, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 28, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 20), serdes: (Serdes6g, 20) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketC
ount { multicast: 31, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 29, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 21), serdes: (Serdes6g, 21) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketC
ount { multicast: 31, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 30, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 22), serdes: (Serdes6g, 22) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketC
ount { multicast: 31, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 31, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 23), serdes: (Serdes6g, 23) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketC
ount { multicast: 31, unicast: 0, broadcast: 0 } } }))
PortStatus(Err(PortStatusError { port: 32, code: Unconfigured }))
PortStatus(Err(PortStatusError { port: 33, code: Unconfigured }))
PortStatus(Err(PortStatusError { port: 34, code: Unconfigured }))
PortStatus(Err(PortStatusError { port: 35, code: Unconfigured }))
PortStatus(Err(PortStatusError { port: 36, code: Unconfigured }))
PortStatus(Err(PortStatusError { port: 37, code: Unconfigured }))
PortStatus(Err(PortStatusError { port: 38, code: Unconfigured }))
PortStatus(Err(PortStatusError { port: 39, code: Unconfigured }))
PortStatus(Ok(PortStatus { port: 40, cfg: PortConfig { mode: Qsgmii(Speed100M), dev: (Dev1g, 16), serdes: (Serdes6g, 14) }, link_status: Up, phy_status: Some(PhyStatus { ty: Vsc8504, mac_link_up: Down, media_link_up: Down }), counters: PortCounters { rx: Pa
cketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCount { multicast: 31, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 41, cfg: PortConfig { mode: Qsgmii(Speed100M), dev: (Dev1g, 17), serdes: (Serdes6g, 14) }, link_status: Up, phy_status: Some(PhyStatus { ty: Vsc8504, mac_link_up: Down, media_link_up: Down }), counters: PortCounters { rx: Pa
cketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCount { multicast: 31, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 42, cfg: PortConfig { mode: Qsgmii(Speed100M), dev: (Dev1g, 18), serdes: (Serdes6g, 14) }, link_status: Up, phy_status: Some(PhyStatus { ty: Vsc8504, mac_link_up: Up, media_link_up: Up }), counters: PortCounters { rx: Packet
Count { multicast: 9, unicast: 0, broadcast: 0 }, tx: PacketCount { multicast: 22, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 43, cfg: PortConfig { mode: Qsgmii(Speed100M), dev: (Dev1g, 19), serdes: (Serdes6g, 14) }, link_status: Up, phy_status: Some(PhyStatus { ty: Vsc8504, mac_link_up: Up, media_link_up: Down }), counters: PortCounters { rx: Pack
etCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCount { multicast: 31, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 44, cfg: PortConfig { mode: Qsgmii(Speed1G), dev: (Dev1g, 20), serdes: (Serdes6g, 15) }, link_status: Up, phy_status: Some(PhyStatus { ty: Vsc8562, mac_link_up: Error, media_link_up: Up }), counters: PortCounters { rx: Packe
tCount { multicast: 3, unicast: 4, broadcast: 0 }, tx: PacketCount { multicast: 28, unicast: 4, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 45, cfg: PortConfig { mode: Qsgmii(Speed1G), dev: (Dev1g, 21), serdes: (Serdes6g, 15) }, link_status: Up, phy_status: Some(PhyStatus { ty: Vsc8562, mac_link_up: Error, media_link_up: Down }), counters: PortCounters { rx: Pac
ketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCount { multicast: 31, unicast: 0, broadcast: 0 } } }))
PortStatus(Err(PortStatusError { port: 46, code: Unconfigured }))
PortStatus(Err(PortStatusError { port: 47, code: Unconfigured }))
PortStatus(Ok(PortStatus { port: 48, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 24), serdes: (Serdes1g, 0) }, link_status: Up, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 10, unicast: 4, broadcast: 0 }, tx: PacketCou
nt { multicast: 21, unicast: 4, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 49, cfg: PortConfig { mode: BaseKr, dev: (Dev10g, 0), serdes: (Serdes10g, 0) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketCount { mult
icast: 31, unicast: 0, broadcast: 0 } } }))
PortStatus(Err(PortStatusError { port: 50, code: Unconfigured }))
PortStatus(Ok(PortStatus { port: 51, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 27), serdes: (Serdes10g, 2) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketC
ount { multicast: 29, unicast: 0, broadcast: 0 } } }))
PortStatus(Ok(PortStatus { port: 52, cfg: PortConfig { mode: Sgmii(Speed100M), dev: (Dev2g5, 28), serdes: (Serdes10g, 3) }, link_status: Down, phy_status: None, counters: PortCounters { rx: PacketCount { multicast: 0, unicast: 0, broadcast: 0 }, tx: PacketC
ount { multicast: 28, unicast: 0, broadcast: 0 } } }))
```