### PR TITLE
Minor tweaks leading to compliance

### DIFF
--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -71,6 +71,7 @@ impl From<DeviceDescription<'_>> for DeviceDescriptionHeader {
 
 /// An index that [`handle_message`] has bounds-checked; see the comments on the
 /// trait methods that accept this type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BoundsChecked(pub u32);
 
 pub trait SpHandler {

--- a/gateway-messages/src/sp_to_mgs/measurement.rs
+++ b/gateway-messages/src/sp_to_mgs/measurement.rs
@@ -64,5 +64,9 @@ pub enum MeasurementKind {
     Power,
     Current,
     Voltage,
+    // These two cases are a little dubious; maybe we need a different way to
+    // represent input vs output?
+    CurrentIn,
+    VoltageIn,
     Speed,
 }


### PR DESCRIPTION
* Add some missing `derive`s
* Extend `MeasurementKind` to add input current/voltage; the way this is modeled doesn't feel right but is workable for now