### PR TITLE
Flesh out ignition support

### DIFF
--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -86,6 +86,14 @@ enum Command {
     /// Ask SP for its current state.
     State,
 
+    /// Get the ignition state for a single target port (only valid if the SP is
+    /// an ignition controller).
+    Ignition { target: u8 },
+
+    /// Get bulk ignition state information (only valid if the SP is an ignition
+    /// controller).
+    BulkIgnition,
+
     /// Get or set startup options on an SP.
     StartupOptions { options: Option<u64> },
 
@@ -228,6 +236,15 @@ async fn main() -> Result<()> {
         }
         Command::State => {
             info!(log, "{:?}", sp.state().await?);
+        }
+        Command::Ignition { target } => {
+            info!(log, "{:?}", sp.ignition_state(target).await?);
+        }
+        Command::BulkIgnition => {
+            let states = sp.bulk_ignition_state().await?;
+            for (i, state) in states.into_iter().enumerate() {
+                println!("target {i}: {state:?}");
+            }
         }
         Command::StartupOptions { options } => {
             if let Some(options) = options {

--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -94,6 +94,14 @@ enum Command {
     /// controller).
     BulkIgnition,
 
+    /// Get bulk ignition link events (only valid if the SP is an ignition
+    /// controller).
+    BulkIgnitionLinkEvents,
+
+    /// Clear all ignition link events (only valid if the SP is an ignition
+    /// controller).
+    ClearIgnitionLinkEvents,
+
     /// Get or set startup options on an SP.
     StartupOptions { options: Option<u64> },
 
@@ -245,6 +253,16 @@ async fn main() -> Result<()> {
             for (i, state) in states.into_iter().enumerate() {
                 println!("target {i}: {state:?}");
             }
+        }
+        Command::BulkIgnitionLinkEvents => {
+            let events = sp.bulk_ignition_link_events().await?;
+            for (i, events) in events.into_iter().enumerate() {
+                println!("target {i}: {events:?}");
+            }
+        }
+        Command::ClearIgnitionLinkEvents => {
+            sp.clear_ignition_link_events().await?;
+            info!(log, "ignition link events cleared");
         }
         Command::StartupOptions { options } => {
             if let Some(options) = options {

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -70,7 +70,7 @@ pub enum MgsRequest {
     BulkIgnitionLinkEvents {
         offset: u32,
     },
-    /// If `target` is `None`, clear events on all target (potentially
+    /// If `target` is `None`, clear events on all targets (potentially
     /// restricted by `transceiver_select`).
     ///
     /// If `transceiver_select` is none, clear events on all transceivers

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -4,6 +4,7 @@
 
 //! Types for messages sent from MGS to SPs.
 
+use crate::ignition::TransceiverSelect;
 use crate::BadRequestReason;
 use crate::PowerState;
 use crate::SpComponent;
@@ -69,9 +70,14 @@ pub enum MgsRequest {
     BulkIgnitionLinkEvents {
         offset: u32,
     },
-    /// If `target` is `None`, clear all target link events.
+    /// If `target` is `None`, clear events on all target (potentially
+    /// restricted by `transceiver_select`).
+    ///
+    /// If `transceiver_select` is none, clear events on all transceivers
+    /// (potentially restricted by `target`).
     ClearIgnitionLinkEvents {
         target: Option<u8>,
+        transceiver_select: Option<TransceiverSelect>,
     },
 }
 

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -61,7 +61,9 @@ pub enum MgsRequest {
         component: SpComponent,
         offset: u32,
     },
-    BulkIgnitionLinkEvents { offset: u32 },
+    BulkIgnitionLinkEvents {
+        offset: u32,
+    },
     ClearIgnitionLinkEvents,
 }
 

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -61,6 +61,8 @@ pub enum MgsRequest {
         component: SpComponent,
         offset: u32,
     },
+    BulkIgnitionLinkEvents { offset: u32 },
+    ClearIgnitionLinkEvents,
 }
 
 #[derive(

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -61,10 +61,14 @@ pub enum MgsRequest {
         component: SpComponent,
         offset: u32,
     },
-    BulkIgnitionLinkEvents {
-        offset: u32,
+    /// Get ignition link events for a single target.
+    IgnitionLinkEvents { target: u8 },
+    /// Get ignition link events for all targets, starting at `offset`.
+    BulkIgnitionLinkEvents { offset: u32 },
+    /// If `target` is `None`, clear all target link events.
+    ClearIgnitionLinkEvents {
+        target: Option<u8>,
     },
-    ClearIgnitionLinkEvents,
 }
 
 #[derive(

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -62,9 +62,13 @@ pub enum MgsRequest {
         offset: u32,
     },
     /// Get ignition link events for a single target.
-    IgnitionLinkEvents { target: u8 },
+    IgnitionLinkEvents {
+        target: u8,
+    },
     /// Get ignition link events for all targets, starting at `offset`.
-    BulkIgnitionLinkEvents { offset: u32 },
+    BulkIgnitionLinkEvents {
+        offset: u32,
+    },
     /// If `target` is `None`, clear all target link events.
     ClearIgnitionLinkEvents {
         target: Option<u8>,

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -20,7 +20,9 @@ pub enum MgsRequest {
     IgnitionState {
         target: u8,
     },
-    BulkIgnitionState,
+    BulkIgnitionState {
+        offset: u32,
+    },
     IgnitionCommand {
         target: u8,
         command: IgnitionCommand,
@@ -93,6 +95,7 @@ pub enum MgsError {
 pub enum IgnitionCommand {
     PowerOn,
     PowerOff,
+    PowerReset,
 }
 
 #[derive(

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -739,6 +739,9 @@ mod tests {
     // Only implements `discover()`; all other methods are left as
     // `unimplemented!()` since no tests are intended to call them.
     impl SpHandler for FakeHandler {
+        type BulkIgnitionStateIter = std::iter::Empty<IgnitionState>;
+        type BulkIgnitionLinkEventsIter = std::iter::Empty<AllLinkEvents>;
+
         fn discover(
             &mut self,
             _sender: SocketAddrV6,
@@ -757,6 +760,42 @@ mod tests {
             _port: SpPort,
             _target: u8,
         ) -> Result<IgnitionState, SpError> {
+            unimplemented!()
+        }
+
+        fn bulk_ignition_state(
+            &mut self,
+            _sender: SocketAddrV6,
+            _port: SpPort,
+            _offset: u32,
+        ) -> Result<Self::BulkIgnitionStateIter, SpError> {
+            unimplemented!()
+        }
+
+        fn bulk_ignition_link_events(
+            &mut self,
+            _sender: SocketAddrV6,
+            _port: SpPort,
+            _offset: u32,
+        ) -> Result<Self::BulkIgnitionLinkEventsIter, SpError> {
+            unimplemented!()
+        }
+
+        fn ignition_link_events(
+            &mut self,
+            _sender: SocketAddrV6,
+            _port: SpPort,
+            _target: u8,
+        ) -> Result<AllLinkEvents, SpError> {
+            unimplemented!()
+        }
+
+        fn clear_ignition_link_events(
+            &mut self,
+            _sender: SocketAddrV6,
+            _port: SpPort,
+            _target: Option<u8>,
+        ) -> Result<(), SpError> {
             unimplemented!()
         }
 
@@ -892,7 +931,7 @@ mod tests {
         fn device_description(
             &mut self,
             _index: BoundsChecked,
-        ) -> DeviceDescription<'_> {
+        ) -> DeviceDescription<'static> {
             unimplemented!()
         }
 

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -804,6 +804,7 @@ mod tests {
             _sender: SocketAddrV6,
             _port: SpPort,
             _target: Option<u8>,
+            _transceiver_select: Option<ignition::TransceiverSelect>,
         ) -> Result<(), SpError> {
             unimplemented!()
         }

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -25,6 +25,7 @@ pub mod vsc7448_port_status;
 pub use ignition::IgnitionState;
 pub use measurement::Measurement;
 
+use ignition::IgnitionError;
 use measurement::MeasurementHeader;
 use vsc7448_port_status::{PortStatus, PortStatusError};
 
@@ -349,8 +350,8 @@ pub enum SpError {
     /// SP; e.g., asking for the serial console of a component that does not
     /// have one.
     RequestUnsupportedForComponent,
-    /// The specified ignition target does not exist.
-    IgnitionTargetDoesNotExist(u8),
+    /// An ignition-related error.
+    Ignition(IgnitionError),
     /// Cannot write to the serial console because it is not attached.
     SerialConsoleNotAttached,
     /// Cannot attach to the serial console because another MGS instance is
@@ -400,8 +401,8 @@ impl fmt::Display for SpError {
             Self::RequestUnsupportedForComponent => {
                 write!(f, "unsupported request for this SP component")
             }
-            Self::IgnitionTargetDoesNotExist(target) => {
-                write!(f, "nonexistent ignition target {}", target)
+            Self::Ignition(err) => {
+                write!(f, "ignition error: {err}")
             }
             Self::SerialConsoleNotAttached => {
                 write!(f, "serial console is not attached")

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -86,6 +86,10 @@ pub enum SpResponse {
     /// A `ComponentDetails` response is followed by a TLV-encoded set of
     /// informational structures (see [`ComponentDetails`]).
     ComponentDetails(TlvPage),
+    /// A `BulkIgnitionLinkEvents` response is followed by a TLV-encoded set of
+    /// [`ignition::AllLinkEvents`]s.
+    BulkIgnitionLinkEvents(TlvPage),
+    ClearIgnitionLinkEventsAck,
 }
 
 /// Identifier for one of of an SP's KSZ8463 management-network-facing ports.

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -28,7 +28,7 @@ pub use measurement::Measurement;
 use measurement::MeasurementHeader;
 use vsc7448_port_status::{PortStatus, PortStatusError};
 
-use ignition::AllLinkEvents;
+use ignition::LinkEvents;
 
 #[derive(
     Debug, Clone, Copy, SerializedSize, Serialize, Deserialize, PartialEq, Eq,
@@ -88,9 +88,9 @@ pub enum SpResponse {
     /// A `ComponentDetails` response is followed by a TLV-encoded set of
     /// informational structures (see [`ComponentDetails`]).
     ComponentDetails(TlvPage),
-    IgnitionLinkEvents(AllLinkEvents),
+    IgnitionLinkEvents(LinkEvents),
     /// A `BulkIgnitionLinkEvents` response is followed by a TLV-encoded set of
-    /// [`ignition::AllLinkEvents`]s.
+    /// [`ignition::LinkEvents`]s.
     BulkIgnitionLinkEvents(TlvPage),
     ClearIgnitionLinkEventsAck,
 }

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -28,6 +28,8 @@ pub use measurement::Measurement;
 use measurement::MeasurementHeader;
 use vsc7448_port_status::{PortStatus, PortStatusError};
 
+use ignition::AllLinkEvents;
+
 #[derive(
     Debug, Clone, Copy, SerializedSize, Serialize, Deserialize, PartialEq, Eq,
 )]
@@ -86,6 +88,7 @@ pub enum SpResponse {
     /// A `ComponentDetails` response is followed by a TLV-encoded set of
     /// informational structures (see [`ComponentDetails`]).
     ComponentDetails(TlvPage),
+    IgnitionLinkEvents(AllLinkEvents),
     /// A `BulkIgnitionLinkEvents` response is followed by a TLV-encoded set of
     /// [`ignition::AllLinkEvents`]s.
     BulkIgnitionLinkEvents(TlvPage),

--- a/gateway-messages/src/sp_to_mgs/ignition.rs
+++ b/gateway-messages/src/sp_to_mgs/ignition.rs
@@ -128,3 +128,28 @@ mod raw_system_type {
     pub(super) const SIDECAR: u16 = 0b0000_0000_0001_0010;
     pub(super) const PSC: u16 = 0b0000_0000_0001_0011;
 }
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
+)]
+pub struct AllLinkEvents {
+    pub controller: LinkEvents,
+    pub target_link0: LinkEvents,
+    pub target_link1: LinkEvents,
+}
+
+impl AllLinkEvents {
+    pub const TAG: tlv::Tag = tlv::Tag(*b"ILE0");
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
+)]
+pub struct LinkEvents {
+    pub encoding_error: bool,
+    pub decoding_error: bool,
+    pub ordered_set_invalid: bool,
+    pub message_version_invalid: bool,
+    pub message_type_invalid: bool,
+    pub message_checksum_invalid: bool,
+}

--- a/gateway-messages/src/sp_to_mgs/ignition.rs
+++ b/gateway-messages/src/sp_to_mgs/ignition.rs
@@ -51,8 +51,8 @@ impl fmt::Display for IgnitionError {
     Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
 )]
 pub struct IgnitionState {
-    pub receiver_status: ReceiverStatus,
-    pub target: Option<Target>,
+    pub receiver: ReceiverStatus,
+    pub target: Option<TargetState>,
 }
 
 impl IgnitionState {
@@ -71,7 +71,7 @@ pub struct ReceiverStatus {
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
 )]
-pub struct Target {
+pub struct TargetState {
     pub system_type: SystemType,
     pub power_state: SystemPowerState,
     pub power_reset_in_progress: bool,

--- a/gateway-messages/src/sp_to_mgs/ignition.rs
+++ b/gateway-messages/src/sp_to_mgs/ignition.rs
@@ -17,15 +17,7 @@ static_assertions::const_assert!(
 );
 
 #[derive(
-    Debug,
-    Default,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    SerializedSize,
-    Serialize,
-    Deserialize,
+    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
 )]
 pub struct IgnitionState {
     pub receiver_status: ReceiverStatus,
@@ -37,15 +29,7 @@ impl IgnitionState {
 }
 
 #[derive(
-    Debug,
-    Default,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    SerializedSize,
-    Serialize,
-    Deserialize,
+    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
 )]
 pub struct ReceiverStatus {
     pub aligned: bool,
@@ -54,39 +38,32 @@ pub struct ReceiverStatus {
 }
 
 #[derive(
-    Debug,
-    Default,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    SerializedSize,
-    Serialize,
-    Deserialize,
+    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
 )]
 pub struct Target {
     pub system_type: SystemType,
+    pub power_state: SystemPowerState,
+    pub power_reset_in_progress: bool,
+    pub faults: SystemFaults,
     pub controller0_present: bool,
     pub controller1_present: bool,
-    pub system_power_abort: bool,
-    pub faults: SystemFaults,
-    pub system_power_off_in_progress: bool,
-    pub system_power_on_in_progress: bool,
-    pub system_power_reset_in_progress: bool,
     pub link0_receiver_status: ReceiverStatus,
     pub link1_receiver_status: ReceiverStatus,
 }
 
 #[derive(
-    Debug,
-    Default,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    SerializedSize,
-    Serialize,
-    Deserialize,
+    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
+)]
+pub enum SystemPowerState {
+    Off,
+    On,
+    Aborted,
+    PoweringOff,
+    PoweringOn,
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
 )]
 pub struct SystemFaults {
     pub power_a3: bool,
@@ -99,16 +76,12 @@ pub struct SystemFaults {
     Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
 )]
 pub enum SystemType {
+    // TODO do we want these specific names or generic ones? MGS proper can also
+    // translate before going out to the control plane, potentially.
     Gimlet,
     Sidecar,
     Psc,
     Unknown(u16),
-}
-
-impl Default for SystemType {
-    fn default() -> Self {
-        Self::Unknown(0)
-    }
 }
 
 impl From<u16> for SystemType {
@@ -132,20 +105,29 @@ mod raw_system_type {
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
 )]
-pub struct AllLinkEvents {
-    pub controller: LinkEvents,
-    pub target_link0: LinkEvents,
-    pub target_link1: LinkEvents,
+pub struct LinkEvents {
+    pub controller: TransceiverEvents,
+    pub target_link0: TransceiverEvents,
+    pub target_link1: TransceiverEvents,
 }
 
-impl AllLinkEvents {
+impl LinkEvents {
     pub const TAG: tlv::Tag = tlv::Tag(*b"ILE0");
 }
 
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
 )]
-pub struct LinkEvents {
+pub enum TransceiverSelect {
+    Controller,
+    TargetLink0,
+    TargetLink1,
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
+)]
+pub struct TransceiverEvents {
     pub encoding_error: bool,
     pub decoding_error: bool,
     pub ordered_set_invalid: bool,

--- a/gateway-messages/src/sp_to_mgs/ignition.rs
+++ b/gateway-messages/src/sp_to_mgs/ignition.rs
@@ -1,0 +1,130 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Types describing ignition state; see RFD 141.
+
+use hubpack::SerializedSize;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::tlv;
+
+// Confirm our expectation that for our current product (35 ports), we can fit
+// the full bulk ignition state into a single UDP packet.
+static_assertions::const_assert!(
+    IgnitionState::MAX_SIZE * 35 <= crate::MIN_TRAILING_DATA_LEN
+);
+
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    SerializedSize,
+    Serialize,
+    Deserialize,
+)]
+pub struct IgnitionState {
+    pub receiver_status: ReceiverStatus,
+    pub target: Option<Target>,
+}
+
+impl IgnitionState {
+    pub const TAG: tlv::Tag = tlv::Tag(*b"IGN0");
+}
+
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    SerializedSize,
+    Serialize,
+    Deserialize,
+)]
+pub struct ReceiverStatus {
+    pub aligned: bool,
+    pub locked: bool,
+    pub polarity_inverted: bool,
+}
+
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    SerializedSize,
+    Serialize,
+    Deserialize,
+)]
+pub struct Target {
+    pub system_type: SystemType,
+    pub controller0_present: bool,
+    pub controller1_present: bool,
+    pub system_power_abort: bool,
+    pub faults: SystemFaults,
+    pub system_power_off_in_progress: bool,
+    pub system_power_on_in_progress: bool,
+    pub system_power_reset_in_progress: bool,
+    pub link0_receiver_status: ReceiverStatus,
+    pub link1_receiver_status: ReceiverStatus,
+}
+
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    SerializedSize,
+    Serialize,
+    Deserialize,
+)]
+pub struct SystemFaults {
+    pub power_a3: bool,
+    pub power_a2: bool,
+    pub sp: bool,
+    pub rot: bool,
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
+)]
+pub enum SystemType {
+    Gimlet,
+    Sidecar,
+    Psc,
+    Unknown(u16),
+}
+
+impl Default for SystemType {
+    fn default() -> Self {
+        Self::Unknown(0)
+    }
+}
+
+impl From<u16> for SystemType {
+    fn from(val: u16) -> Self {
+        match val {
+            raw_system_type::GIMLET => Self::Gimlet,
+            raw_system_type::SIDECAR => Self::Sidecar,
+            raw_system_type::PSC => Self::Psc,
+            _ => Self::Unknown(val),
+        }
+    }
+}
+
+// Constant values from RFD 141.
+mod raw_system_type {
+    pub(super) const GIMLET: u16 = 0b0000_0000_0001_0001;
+    pub(super) const SIDECAR: u16 = 0b0000_0000_0001_0010;
+    pub(super) const PSC: u16 = 0b0000_0000_0001_0011;
+}

--- a/gateway-messages/src/sp_to_mgs/ignition.rs
+++ b/gateway-messages/src/sp_to_mgs/ignition.rs
@@ -4,6 +4,7 @@
 
 //! Types describing ignition state; see RFD 141.
 
+use core::fmt;
 use hubpack::SerializedSize;
 use serde::Deserialize;
 use serde::Serialize;
@@ -15,6 +16,36 @@ use crate::tlv;
 static_assertions::const_assert!(
     IgnitionState::MAX_SIZE * 35 <= crate::MIN_TRAILING_DATA_LEN
 );
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
+)]
+pub enum IgnitionError {
+    FpgaError,
+    InvalidPort,
+    InvalidValue,
+    NoTargetPresent,
+    RequestInProgress,
+    RequestDiscarded,
+    Other(u32),
+}
+
+impl fmt::Display for IgnitionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            IgnitionError::FpgaError => "fpga communication error",
+            IgnitionError::InvalidPort => "invalid target",
+            IgnitionError::InvalidValue => "invalid value",
+            IgnitionError::NoTargetPresent => "no target present",
+            IgnitionError::RequestInProgress => "request in progress",
+            IgnitionError::RequestDiscarded => "request discarded",
+            IgnitionError::Other(code) => {
+                return write!(f, "other (code = {code})");
+            }
+        };
+        write!(f, "{s}")
+    }
+}
 
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,

--- a/gateway-sp-comms/src/error.rs
+++ b/gateway-sp-comms/src/error.rs
@@ -61,8 +61,8 @@ pub enum SpCommunicationError {
     TlvDeserialize { tag: tlv::Tag, err: gateway_messages::HubpackError },
     #[error("failed to decode TLV triple: {0}")]
     TlvDecode(#[from] tlv::DecodeError),
-    #[error("invalid TLV pagination: {reason}")]
-    TlvPagination { reason: &'static str },
+    #[error("invalid pagination: {reason}")]
+    Pagination { reason: &'static str },
 }
 
 #[derive(Debug, Error)]

--- a/gateway-sp-comms/src/error.rs
+++ b/gateway-sp-comms/src/error.rs
@@ -62,7 +62,7 @@ pub enum SpCommunicationError {
     #[error("failed to decode TLV triple: {0}")]
     TlvDecode(#[from] tlv::DecodeError),
     #[error("invalid pagination: {reason}")]
-    Pagination { reason: &'static str },
+    TlvPagination { reason: &'static str },
 }
 
 #[derive(Debug, Error)]

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -220,6 +220,18 @@ impl SingleSp {
             .await
     }
 
+    /// Request link events for a single ignition target.
+    ///
+    /// This will fail if this SP is not connected to an ignition controller.
+    pub async fn ignition_link_events(
+        &self,
+        target: u8,
+    ) -> Result<AllLinkEvents> {
+        self.rpc(MgsRequest::IgnitionLinkEvents { target }).await.and_then(
+            |(_peer, response, _data)| response.expect_ignition_link_events(),
+        )
+    }
+
     /// Request all link events on all ignition targets.
     ///
     /// This will fail if this SP is not connected to an ignition controller.
@@ -235,15 +247,26 @@ impl SingleSp {
         .await
     }
 
+    /// Clear ignition link events for a single target.
+    ///
+    /// This will fail if this SP is not connected to an ignition controller.
+    pub async fn clear_ignition_link_events(&self, target: u8) -> Result<()> {
+        self.rpc(MgsRequest::ClearIgnitionLinkEvents { target: Some(target) })
+            .await
+            .and_then(|(_peer, response, _data)| {
+                response.expect_clear_ignition_link_events_ack()
+            })
+    }
+
     /// Clear all ignition link events.
     ///
     /// This will fail if this SP is not connected to an ignition controller.
-    pub async fn clear_ignition_link_events(&self) -> Result<()> {
-        self.rpc(MgsRequest::ClearIgnitionLinkEvents).await.and_then(
-            |(_peer, response, _data)| {
+    pub async fn clear_all_ignition_link_events(&self) -> Result<()> {
+        self.rpc(MgsRequest::ClearIgnitionLinkEvents { target: None })
+            .await
+            .and_then(|(_peer, response, _data)| {
                 response.expect_clear_ignition_link_events_ack()
-            },
-        )
+            })
     }
 
     /// Send an ignition command to the given target.

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -791,10 +791,7 @@ impl TlvRpc for BulkIgnitionStateTlvRpc<'_> {
                 Ok(Some(state))
             }
             _ => {
-                info!(
-                    self.log,
-                    "skipping unknown ignition state tag {tag:?}"
-                );
+                info!(self.log, "skipping unknown ignition state tag {tag:?}");
                 Ok(None)
             }
         }

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::error::SpCommunicationError;
-use gateway_messages::ignition::AllLinkEvents;
+use gateway_messages::ignition::LinkEvents;
 use gateway_messages::DiscoverResponse;
 use gateway_messages::IgnitionState;
 use gateway_messages::PowerState;
@@ -26,7 +26,7 @@ pub(crate) trait SpResponseExt {
 
     fn expect_bulk_ignition_state(self) -> Result<TlvPage>;
 
-    fn expect_ignition_link_events(self) -> Result<AllLinkEvents>;
+    fn expect_ignition_link_events(self) -> Result<LinkEvents>;
 
     fn expect_bulk_ignition_link_events(self) -> Result<TlvPage>;
 
@@ -152,7 +152,7 @@ impl SpResponseExt for SpResponse {
         }
     }
 
-    fn expect_ignition_link_events(self) -> Result<AllLinkEvents> {
+    fn expect_ignition_link_events(self) -> Result<LinkEvents> {
         match self {
             Self::IgnitionLinkEvents(events) => Ok(events),
             Self::Error(err) => Err(SpCommunicationError::SpError(err)),

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::error::SpCommunicationError;
+use gateway_messages::ignition::AllLinkEvents;
 use gateway_messages::DiscoverResponse;
 use gateway_messages::IgnitionState;
 use gateway_messages::PowerState;
@@ -11,7 +12,6 @@ use gateway_messages::SpState;
 use gateway_messages::StartupOptions;
 use gateway_messages::TlvPage;
 use gateway_messages::UpdateStatus;
-use gateway_messages::ignition::AllLinkEvents;
 
 type Result<T> = std::result::Result<T, SpCommunicationError>;
 

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -3,7 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::error::SpCommunicationError;
-use gateway_messages::BulkIgnitionState;
 use gateway_messages::DiscoverResponse;
 use gateway_messages::IgnitionState;
 use gateway_messages::PowerState;
@@ -26,7 +25,7 @@ pub(crate) trait SpResponseExt {
 
     fn expect_bulk_ignition_state(
         self,
-    ) -> Result<BulkIgnitionState, SpCommunicationError>;
+    ) -> Result<TlvPage, SpCommunicationError>;
 
     fn expect_ignition_command_ack(self) -> Result<(), SpCommunicationError>;
 
@@ -144,9 +143,9 @@ impl SpResponseExt for SpResponse {
 
     fn expect_bulk_ignition_state(
         self,
-    ) -> Result<BulkIgnitionState, SpCommunicationError> {
+    ) -> Result<TlvPage, SpCommunicationError> {
         match self {
-            Self::BulkIgnitionState(state) => Ok(state),
+            Self::BulkIgnitionState(page) => Ok(page),
             Self::Error(err) => Err(SpCommunicationError::SpError(err)),
             other => Err(SpCommunicationError::BadResponseType {
                 expected: response_kind_names::BULK_IGNITION_STATE,

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -11,6 +11,7 @@ use gateway_messages::SpState;
 use gateway_messages::StartupOptions;
 use gateway_messages::TlvPage;
 use gateway_messages::UpdateStatus;
+use gateway_messages::ignition::AllLinkEvents;
 
 type Result<T> = std::result::Result<T, SpCommunicationError>;
 
@@ -24,6 +25,8 @@ pub(crate) trait SpResponseExt {
     fn expect_ignition_state(self) -> Result<IgnitionState>;
 
     fn expect_bulk_ignition_state(self) -> Result<TlvPage>;
+
+    fn expect_ignition_link_events(self) -> Result<AllLinkEvents>;
 
     fn expect_bulk_ignition_link_events(self) -> Result<TlvPage>;
 
@@ -69,6 +72,9 @@ impl SpResponseExt for SpResponse {
         match self {
             Self::Discover(_) => response_kind_names::DISCOVER,
             Self::IgnitionState(_) => response_kind_names::IGNITION_STATE,
+            Self::IgnitionLinkEvents(_) => {
+                response_kind_names::IGNITION_LINK_EVENTS
+            }
             Self::BulkIgnitionState(_) => {
                 response_kind_names::BULK_IGNITION_STATE
             }
@@ -141,6 +147,17 @@ impl SpResponseExt for SpResponse {
             Self::Error(err) => Err(SpCommunicationError::SpError(err)),
             other => Err(SpCommunicationError::BadResponseType {
                 expected: response_kind_names::BULK_IGNITION_STATE,
+                got: other.name(),
+            }),
+        }
+    }
+
+    fn expect_ignition_link_events(self) -> Result<AllLinkEvents> {
+        match self {
+            Self::IgnitionLinkEvents(events) => Ok(events),
+            Self::Error(err) => Err(SpCommunicationError::SpError(err)),
+            other => Err(SpCommunicationError::BadResponseType {
+                expected: response_kind_names::IGNITION_LINK_EVENTS,
                 got: other.name(),
             }),
         }
@@ -362,6 +379,7 @@ mod response_kind_names {
     pub(super) const DISCOVER: &str = "discover";
     pub(super) const IGNITION_STATE: &str = "ignition_state";
     pub(super) const BULK_IGNITION_STATE: &str = "bulk_ignition_state";
+    pub(super) const IGNITION_LINK_EVENTS: &str = "ignition_link_events";
     pub(super) const BULK_IGNITION_LINK_EVENTS: &str =
         "bulk_ignition_link_events";
     pub(super) const IGNITION_COMMAND_ACK: &str = "ignition_command_ack";


### PR DESCRIPTION
We previously had some placeholder messages for ignition (based on an early RFD); now that ignition has landed in hubris, this fleshes out those messages to match it.

The bulk of this PR is adding new messages to get ignition state and link event state (for single targets or in bulk). Other notable changes:

* In `sp_impl.rs`, we now have a generic method to encode TLV triples at the end of a packet instead of having separate functions for each message type. Different messages have different serialization issues, so it takes an iterator that yields closures to perform the serialization; this feels a little awkward - suggestions very welcome.
* The TODO comments in `single_sp.rs` related to ignition only returning state for 35 targets (32 sleds, 2 psc, and the _other_ sidecar - not itself). This will require some thought/rework when we go to integrate into MGS proper, but I'm not sure how to handle that now, hence the TODOs.