### PR TITLE
Update vsc7448/monorail counters

### DIFF
--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -95,6 +95,9 @@ enum Command {
     /// Ask SP for details of a component.
     ComponentDetails { component: String },
 
+    /// Ask SP to clear the state (e.g., reset counters) on a component.
+    ComponentClearStatus { component: String },
+
     /// Attach to the SP's USART.
     UsartAttach {
         /// Put the local terminal in raw mode.
@@ -268,6 +271,14 @@ async fn main() -> Result<()> {
             for entry in details.entries {
                 println!("{entry:?}");
             }
+        }
+        Command::ComponentClearStatus { component } => {
+            let sp_component = SpComponent::try_from(component.as_str())
+                .map_err(|_| {
+                    anyhow!("invalid component name: {}", component)
+                })?;
+            sp.component_clear_status(sp_component).await?;
+            info!(log, "status cleared for component {component}");
         }
         Command::UsartAttach { raw, stdin_buffer_time_millis } => {
             usart::run(

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -137,8 +137,8 @@ impl SpComponent {
     /// The host CPU boot flash.
     pub const HOST_CPU_BOOT_FLASH: Self = Self { id: *b"host-boot-flash\0" };
 
-    /// The sidecar VSC7448 switch.
-    pub const VSC7448: Self = Self { id: *b"vsc7448\0\0\0\0\0\0\0\0\0" };
+    /// The sidecar management network switch.
+    pub const MONORAIL: Self = Self { id: *b"monorail\0\0\0\0\0\0\0\0" };
 
     /// Prefix for devices that are identified generically by index (e.g.,
     /// `dev-17`).

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -59,6 +59,8 @@ pub enum MgsRequest {
         component: SpComponent,
         offset: u32,
     },
+    /// Clear any clearable state (e.g., event counters) on a component.
+    ComponentClearStatus(SpComponent),
 }
 
 #[derive(

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -242,6 +242,13 @@ pub trait SpHandler {
         index: BoundsChecked,
     ) -> ComponentDetails;
 
+    fn component_clear_status(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        component: SpComponent,
+    ) -> Result<(), SpError>;
+
     fn get_startup_options(
         &mut self,
         sender: SocketAddrV6,
@@ -676,6 +683,9 @@ fn handle_mgs_request<H: SpHandler>(
                     total: total_items,
                 })
             }),
+        MgsRequest::ComponentClearStatus(component) => handler
+            .component_clear_status(sender, port, component)
+            .map(|()| SpResponse::ComponentClearStatusAck),
     };
 
     let response = match result {
@@ -877,6 +887,15 @@ mod tests {
             _component: SpComponent,
             _index: BoundsChecked,
         ) -> ComponentDetails {
+            unimplemented!()
+        }
+
+        fn component_clear_status(
+            &mut self,
+            _sender: SocketAddrV6,
+            _port: SpPort,
+            _component: SpComponent,
+        ) -> Result<(), SpError> {
             unimplemented!()
         }
 

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -19,11 +19,11 @@ use serde_repr::Deserialize_repr;
 use serde_repr::Serialize_repr;
 
 pub mod measurement;
-pub mod vsc7448_port_status;
+pub mod monorail_port_status;
 
 pub use measurement::Measurement;
 use measurement::MeasurementHeader;
-use vsc7448_port_status::{PortStatus, PortStatusError};
+use monorail_port_status::{PortStatus, PortStatusError};
 
 #[derive(
     Debug, Clone, Copy, SerializedSize, Serialize, Deserialize, PartialEq, Eq,

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -451,6 +451,9 @@ pub enum SpError {
     /// Request mentioned a slot number for a component that does not have that
     /// slot.
     InvalidSlotForComponent,
+    /// The requested operation on the component failed with the associated
+    /// code.
+    ComponentOperationFailed(u32),
 }
 
 impl fmt::Display for SpError {
@@ -510,6 +513,9 @@ impl fmt::Display for SpError {
             }
             Self::InvalidSlotForComponent => {
                 write!(f, "invalid slot number for component")
+            }
+            Self::ComponentOperationFailed(code) => {
+                write!(f, "component operation failed (code {code})")
             }
         }
     }

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -81,6 +81,7 @@ pub enum SpResponse {
     /// A `ComponentDetails` response is followed by a TLV-encoded set of
     /// informational structures (see [`ComponentDetails`]).
     ComponentDetails(TlvPage),
+    ComponentClearStatusAck,
 }
 
 #[derive(

--- a/gateway-messages/src/sp_to_mgs/monorail_port_status.rs
+++ b/gateway-messages/src/sp_to_mgs/monorail_port_status.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! Types for sidecar SP reporting VSC7448 port status.
+//! Types for sidecar SP reporting Monorail port status.
 
 use crate::tlv;
 use hubpack::SerializedSize;

--- a/gateway-messages/src/sp_to_mgs/vsc7448_port_status.rs
+++ b/gateway-messages/src/sp_to_mgs/vsc7448_port_status.rs
@@ -89,6 +89,8 @@ pub struct PacketCount {
 pub struct PortCounters {
     pub rx: PacketCount,
     pub tx: PacketCount,
+    pub link_down_sticky: bool,
+    pub phy_link_down_sticky: bool,
 }
 
 #[derive(

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -264,6 +264,19 @@ impl SingleSp {
         Ok(SpComponentDetails { entries })
     }
 
+    /// Request that the status of a component be cleared (e.g., resetting
+    /// counters).
+    pub async fn component_clear_status(
+        &self,
+        component: SpComponent,
+    ) -> Result<()> {
+        self.rpc(MgsRequest::ComponentClearStatus(component)).await.and_then(
+            |(_peer, response, _data)| {
+                response.expect_component_clear_status_ack()
+            },
+        )
+    }
+
     async fn get_paginated_tlv_data<T: TlvRpc>(
         &self,
         rpc: T,

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -677,8 +677,8 @@ impl TlvRpc for ComponentDetailsTlvRpc<'_> {
     ) -> Result<Option<Self::Item>> {
         use gateway_messages::measurement::Measurement;
         use gateway_messages::measurement::MeasurementHeader;
-        use gateway_messages::vsc7448_port_status::PortStatus;
-        use gateway_messages::vsc7448_port_status::PortStatusError;
+        use gateway_messages::monorail_port_status::PortStatus;
+        use gateway_messages::monorail_port_status::PortStatusError;
 
         match tag {
             PortStatus::TAG => {

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -73,6 +73,10 @@ pub(crate) trait SpResponseExt {
         -> Result<(), SpCommunicationError>;
 
     fn expect_component_details(self) -> Result<TlvPage, SpCommunicationError>;
+
+    fn expect_component_clear_status_ack(
+        self,
+    ) -> Result<(), SpCommunicationError>;
 }
 
 impl SpResponseExt for SpResponse {
@@ -115,6 +119,9 @@ impl SpResponseExt for SpResponse {
                 response_kind_names::SET_STARTUP_OPTIONS_ACK
             }
             Self::ComponentDetails(_) => response_kind_names::COMPONENT_DETAILS,
+            Self::ComponentClearStatusAck => {
+                response_kind_names::COMPONENT_CLEAR_STATUS_ACK
+            }
         }
     }
 
@@ -357,6 +364,19 @@ impl SpResponseExt for SpResponse {
             }),
         }
     }
+
+    fn expect_component_clear_status_ack(
+        self,
+    ) -> Result<(), SpCommunicationError> {
+        match self {
+            Self::ComponentClearStatusAck => Ok(()),
+            Self::Error(err) => Err(SpCommunicationError::SpError(err)),
+            other => Err(SpCommunicationError::BadResponseType {
+                expected: response_kind_names::COMPONENT_CLEAR_STATUS_ACK,
+                got: other.name(),
+            }),
+        }
+    }
 }
 
 mod response_kind_names {
@@ -385,4 +405,6 @@ mod response_kind_names {
     pub(super) const STARTUP_OPTIONS: &str = "startup_options";
     pub(super) const SET_STARTUP_OPTIONS_ACK: &str = "set_startup_options_ack";
     pub(super) const COMPONENT_DETAILS: &str = "component_details";
+    pub(super) const COMPONENT_CLEAR_STATUS_ACK: &str =
+        "component_clear_status_ack";
 }


### PR DESCRIPTION
This PR adds:

* A `ClearComponentStatus(_)` command (currently only implemented by the sidecar monorail, which it takes to mean "reset all counters")
* The new link flapping booleans to `PortCounters`

and renames "vsc7448" -> "monorail".