### PR TITLE
Add messages to get/set component active slot

### DIFF
--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -81,6 +81,18 @@ pub enum MgsRequest {
     },
     /// Clear any clearable state (e.g., event counters) on a component.
     ComponentClearStatus(SpComponent),
+    /// For components with multiple slots (e.g., host boot flash), get the
+    /// currently-active slot.
+    ComponentGetActiveSlot(SpComponent),
+    /// For components with multiple slots (e.g., host boot flash), set the
+    /// currently-active slot.
+    ///
+    /// The effect/timing of setting the active slot is component-defined; e.g.,
+    /// it make not take effect until the component or SP is next booted.
+    ComponentSetActiveSlot {
+        component: SpComponent,
+        slot: u16,
+    },
 }
 
 #[derive(

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -281,6 +281,21 @@ pub trait SpHandler {
         component: SpComponent,
     ) -> Result<(), SpError>;
 
+    fn component_get_active_slot(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        component: SpComponent,
+    ) -> Result<u16, SpError>;
+
+    fn component_set_active_slot(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        component: SpComponent,
+        slot: u16,
+    ) -> Result<(), SpError>;
+
     fn get_startup_options(
         &mut self,
         sender: SocketAddrV6,
@@ -730,6 +745,12 @@ fn handle_mgs_request<H: SpHandler>(
         MgsRequest::ComponentClearStatus(component) => handler
             .component_clear_status(sender, port, component)
             .map(|()| SpResponse::ComponentClearStatusAck),
+        MgsRequest::ComponentGetActiveSlot(component) => handler
+            .component_get_active_slot(sender, port, component)
+            .map(SpResponse::ComponentActiveSlot),
+        MgsRequest::ComponentSetActiveSlot { component, slot } => handler
+            .component_set_active_slot(sender, port, component, slot)
+            .map(|()| SpResponse::ComponentSetActiveSlotAck),
     };
 
     let response = match result {
@@ -1017,6 +1038,25 @@ mod tests {
             _offset: u64,
             _data: &[u8],
         ) {
+            unimplemented!()
+        }
+
+        fn component_get_active_slot(
+            &mut self,
+            _sender: SocketAddrV6,
+            _port: SpPort,
+            _component: SpComponent,
+        ) -> Result<u16, SpError> {
+            unimplemented!()
+        }
+
+        fn component_set_active_slot(
+            &mut self,
+            _sender: SocketAddrV6,
+            _port: SpPort,
+            _component: SpComponent,
+            _slot: u16,
+        ) -> Result<(), SpError> {
             unimplemented!()
         }
     }

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -95,6 +95,8 @@ pub enum SpResponse {
     BulkIgnitionLinkEvents(TlvPage),
     ClearIgnitionLinkEventsAck,
     ComponentClearStatusAck,
+    ComponentActiveSlot(u16),
+    ComponentSetActiveSlotAck,
 }
 
 /// Identifier for one of of an SP's KSZ8463 management-network-facing ports.

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -312,6 +312,29 @@ impl SingleSp {
         Ok(SpComponentDetails { entries })
     }
 
+    /// Get the currently-active slot of a particular component.
+    pub async fn component_active_slot(
+        &self,
+        component: SpComponent,
+    ) -> Result<u16> {
+        self.rpc(MgsRequest::ComponentGetActiveSlot(component)).await.and_then(
+            |(_peer, response, _data)| response.expect_component_active_slot(),
+        )
+    }
+
+    /// Set the currently-active slot of a particular component.
+    pub async fn set_component_active_slot(
+        &self,
+        component: SpComponent,
+        slot: u16,
+    ) -> Result<()> {
+        self.rpc(MgsRequest::ComponentSetActiveSlot { component, slot })
+            .await
+            .and_then(|(_peer, response, _data)| {
+                response.expect_component_set_active_slot_ack()
+            })
+    }
+
     /// Request that the status of a component be cleared (e.g., resetting
     /// counters).
     pub async fn component_clear_status(

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -67,6 +67,10 @@ pub(crate) trait SpResponseExt {
     fn expect_component_details(self) -> Result<TlvPage>;
 
     fn expect_component_clear_status_ack(self) -> Result<()>;
+
+    fn expect_component_active_slot(self) -> Result<u16>;
+
+    fn expect_component_set_active_slot_ack(self) -> Result<()>;
 }
 
 impl SpResponseExt for SpResponse {
@@ -120,6 +124,12 @@ impl SpResponseExt for SpResponse {
             Self::ComponentDetails(_) => response_kind_names::COMPONENT_DETAILS,
             Self::ComponentClearStatusAck => {
                 response_kind_names::COMPONENT_CLEAR_STATUS_ACK
+            }
+            Self::ComponentActiveSlot(_) => {
+                response_kind_names::COMPONENT_ACTIVE_SLOT
+            }
+            Self::ComponentSetActiveSlotAck => {
+                response_kind_names::COMPONENT_SET_ACTIVE_SLOT_ACK
             }
         }
     }
@@ -389,6 +399,28 @@ impl SpResponseExt for SpResponse {
             }),
         }
     }
+
+    fn expect_component_active_slot(self) -> Result<u16> {
+        match self {
+            Self::ComponentActiveSlot(slot) => Ok(slot),
+            Self::Error(err) => Err(SpCommunicationError::SpError(err)),
+            other => Err(SpCommunicationError::BadResponseType {
+                expected: response_kind_names::COMPONENT_ACTIVE_SLOT,
+                got: other.name(),
+            }),
+        }
+    }
+
+    fn expect_component_set_active_slot_ack(self) -> Result<()> {
+        match self {
+            Self::ComponentSetActiveSlotAck => Ok(()),
+            Self::Error(err) => Err(SpCommunicationError::SpError(err)),
+            other => Err(SpCommunicationError::BadResponseType {
+                expected: response_kind_names::COMPONENT_SET_ACTIVE_SLOT_ACK,
+                got: other.name(),
+            }),
+        }
+    }
 }
 
 mod response_kind_names {
@@ -424,4 +456,7 @@ mod response_kind_names {
     pub(super) const COMPONENT_DETAILS: &str = "component_details";
     pub(super) const COMPONENT_CLEAR_STATUS_ACK: &str =
         "component_clear_status_ack";
+    pub(super) const COMPONENT_ACTIVE_SLOT: &str = "component_active_slot";
+    pub(super) const COMPONENT_SET_ACTIVE_SLOT_ACK: &str =
+        "component_set_active_slot_ack";
 }


### PR DESCRIPTION
This is primarily intended for getting/setting the active host boot flash slot (0 or 1) for now, but could be used for other components in the future.