### PR TITLE
Add APIs to send NMI and UART break

### DIFF
--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -242,6 +242,9 @@ enum Command {
         new_power_state: Option<PowerState>,
     },
 
+    /// Sends an NMI to the host (SP3) CPU by toggling a GPIO
+    SendHostNmi,
+
     /// Instruct the SP to reset.
     Reset,
 }
@@ -809,6 +812,10 @@ async fn run_command(
             sp.reset_trigger().await?;
             info!(log, "SP reset complete");
             Ok(vec!["reset complete".to_string()])
+        }
+        Command::SendHostNmi => {
+            sp.send_host_nmi().await?;
+            Ok(vec!["done".to_string()])
         }
     }
 }

--- a/faux-mgs/src/usart.rs
+++ b/faux-mgs/src/usart.rs
@@ -99,6 +99,7 @@ pub(crate) async fn run(
                         send_tx.send(SendTxData::Break)
                             .await
                             .with_context(|| "failed to send data (task shutdown?)")?;
+                        println!("\n*** break sent ***");
                     }
                 }
 

--- a/faux-mgs/src/usart.rs
+++ b/faux-mgs/src/usart.rs
@@ -99,7 +99,7 @@ pub(crate) async fn run(
                         send_tx.send(SendTxData::Break)
                             .await
                             .with_context(|| "failed to send data (task shutdown?)")?;
-                        println!("\n*** break sent ***");
+                        println!("\n\r*** break sent ***\r");
                     }
                 }
 

--- a/faux-mgs/src/usart.rs
+++ b/faux-mgs/src/usart.rs
@@ -24,6 +24,7 @@ use crate::picocom_map::RemapRules;
 
 const CTRL_A: u8 = b'\x01';
 const CTRL_X: u8 = b'\x18';
+const CTRL_BACKSLASH: u8 = b'\x1c';
 
 pub(crate) async fn run(
     sp: SingleSp,
@@ -94,6 +95,11 @@ pub(crate) async fn run(
                         tx_to_sp_handle.await.unwrap();
                         return Ok(());
                     }
+                    IngestResult::Break => {
+                        send_tx.send(SendTxData::Break)
+                            .await
+                            .with_context(|| "failed to send data (task shutdown?)")?;
+                    }
                 }
 
                 flush_delay.start_if_unstarted().await;
@@ -117,7 +123,7 @@ pub(crate) async fn run(
 
             _ = flush_delay.ready() => {
                 send_tx
-                    .send(out_buf.steal_buf())
+                    .send(SendTxData::Buf(out_buf.steal_buf()))
                     .await
                     .with_context(|| "failed to send data (task shutdown?)")?;
             }
@@ -127,14 +133,23 @@ pub(crate) async fn run(
 
 async fn relay_data_to_sp(
     mut console_tx: AttachedSerialConsoleSend,
-    mut data_rx: mpsc::Receiver<Vec<u8>>,
+    mut data_rx: mpsc::Receiver<SendTxData>,
 ) -> Result<()> {
     while let Some(data) = data_rx.recv().await {
-        console_tx.write(data).await?;
+        match data {
+            SendTxData::Buf(buf) => console_tx.write(buf).await?,
+            SendTxData::Break => console_tx.send_break().await?,
+        }
     }
     console_tx.detach().await?;
 
     Ok(())
+}
+
+#[derive(Debug)]
+enum SendTxData {
+    Buf(Vec<u8>),
+    Break,
 }
 
 struct UnrawTermiosGuard {
@@ -211,6 +226,9 @@ struct StdinOutBuf {
 enum IngestResult {
     Ok,
     Exit,
+
+    /// Send a break on the UART
+    Break,
 }
 
 impl StdinOutBuf {
@@ -241,6 +259,13 @@ impl StdinOutBuf {
                     if self.in_prefix {
                         // Exit on Ctrl-A Ctrl-X
                         return IngestResult::Exit;
+                    } else {
+                        self.buf.push(c);
+                    }
+                }
+                CTRL_BACKSLASH => {
+                    if self.in_prefix {
+                        return IngestResult::Break;
                     } else {
                         self.buf.push(c);
                     }

--- a/faux-mgs/src/usart.rs
+++ b/faux-mgs/src/usart.rs
@@ -245,6 +245,7 @@ impl StdinOutBuf {
             return IngestResult::Ok;
         }
 
+        let mut result = IngestResult::Ok;
         for c in buf {
             match c {
                 CTRL_A => {
@@ -266,7 +267,11 @@ impl StdinOutBuf {
                 }
                 CTRL_BACKSLASH => {
                     if self.in_prefix {
-                        return IngestResult::Break;
+                        // Keep processing the buffer, but return a flag
+                        // indicating that the host wants a USART break to be
+                        // sent.
+                        result = IngestResult::Break;
+                        self.in_prefix = false;
                     } else {
                         self.buf.push(c);
                     }
@@ -278,7 +283,7 @@ impl StdinOutBuf {
             }
         }
 
-        IngestResult::Ok
+        result
     }
 
     fn steal_buf(&mut self) -> Vec<u8> {

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -93,6 +93,10 @@ pub enum MgsRequest {
         component: SpComponent,
         slot: u16,
     },
+    /// Send a break on the host serial console
+    SerialConsoleBreak,
+    /// Send an NMI to the host by toggling a GPIO
+    SendHostNmi,
 }
 
 #[derive(

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -214,6 +214,12 @@ pub trait SpHandler {
         port: SpPort,
     ) -> Result<(), SpError>;
 
+    fn serial_console_break(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+    ) -> Result<(), SpError>;
+
     fn reset_prepare(
         &mut self,
         sender: SocketAddrV6,
@@ -326,6 +332,11 @@ pub trait SpHandler {
         offset: u64,
         data: &[u8],
     );
+    fn send_host_nmi(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+    ) -> Result<(), SpError>;
 }
 
 /// Handle a single incoming message.
@@ -683,6 +694,9 @@ fn handle_mgs_request<H: SpHandler>(
         MgsRequest::SerialConsoleDetach => handler
             .serial_console_detach(sender, port)
             .map(|()| SpResponse::SerialConsoleDetachAck),
+        MgsRequest::SerialConsoleBreak => handler
+            .serial_console_break(sender, port)
+            .map(|()| SpResponse::SerialConsoleBreakAck),
         MgsRequest::GetPowerState => {
             handler.power_state(sender, port).map(SpResponse::PowerState)
         }
@@ -751,6 +765,9 @@ fn handle_mgs_request<H: SpHandler>(
         MgsRequest::ComponentSetActiveSlot { component, slot } => handler
             .component_set_active_slot(sender, port, component, slot)
             .map(|()| SpResponse::ComponentSetActiveSlotAck),
+        MgsRequest::SendHostNmi => handler
+            .send_host_nmi(sender, port)
+            .map(|()| SpResponse::SendHostNmiAck),
     };
 
     let response = match result {
@@ -949,6 +966,14 @@ mod tests {
             unimplemented!()
         }
 
+        fn serial_console_break(
+            &mut self,
+            _sender: SocketAddrV6,
+            _port: SpPort,
+        ) -> Result<(), SpError> {
+            unimplemented!()
+        }
+
         fn reset_prepare(
             &mut self,
             _sender: SocketAddrV6,
@@ -1056,6 +1081,14 @@ mod tests {
             _port: SpPort,
             _component: SpComponent,
             _slot: u16,
+        ) -> Result<(), SpError> {
+            unimplemented!()
+        }
+
+        fn send_host_nmi(
+            &mut self,
+            _sender: SocketAddrV6,
+            _port: SpPort,
         ) -> Result<(), SpError> {
             unimplemented!()
         }

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -97,6 +97,8 @@ pub enum SpResponse {
     ComponentClearStatusAck,
     ComponentActiveSlot(u16),
     ComponentSetActiveSlotAck,
+    SerialConsoleBreakAck,
+    SendHostNmiAck,
 }
 
 /// Identifier for one of of an SP's KSZ8463 management-network-facing ports.

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -1072,17 +1072,12 @@ impl AttachedSerialConsoleSend {
     }
 
     pub async fn send_break(&self) -> Result<()> {
-        let (tx, rx) = oneshot::channel();
-        self.inner_tx
-            .send(InnerCommand::Rpc(RpcRequest {
-                kind: MgsRequest::SerialConsoleBreak,
-                our_trailing_data: None,
-                response_tx: tx,
-            }))
+        rpc(&self.inner_tx, MgsRequest::SerialConsoleBreak, None)
             .await
-            .unwrap();
-        rx.await.unwrap();
-        Ok(())
+            .result
+            .and_then(|(_peer, response, _data)| {
+                response.expect_serial_console_break_ack()
+            })
     }
 }
 

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -667,6 +667,12 @@ impl SingleSp {
     ) -> Result<(SocketAddrV6, SpResponse, Vec<u8>)> {
         rpc(&self.cmds_tx, kind, None).await.result
     }
+
+    pub async fn send_host_nmi(&self) -> Result<()> {
+        self.rpc(MgsRequest::SendHostNmi).await.and_then(
+            |(_peer, response, _data)| response.expect_send_host_nmi_ack(),
+        )
+    }
 }
 
 // Helper trait to call a "paginated" (i.e., split across multiple UDP packets)

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -1070,6 +1070,20 @@ impl AttachedSerialConsoleSend {
 
         rx.await.unwrap()
     }
+
+    pub async fn send_break(&self) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.inner_tx
+            .send(InnerCommand::Rpc(RpcRequest {
+                kind: MgsRequest::SerialConsoleBreak,
+                our_trailing_data: None,
+                response_tx: tx,
+            }))
+            .await
+            .unwrap();
+        rx.await.unwrap();
+        Ok(())
+    }
 }
 
 #[derive(Debug)]

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -73,6 +73,8 @@ pub(crate) trait SpResponseExt {
     fn expect_component_active_slot(self) -> Result<u16>;
 
     fn expect_component_set_active_slot_ack(self) -> Result<()>;
+
+    fn expect_send_host_nmi_ack(self) -> Result<()>;
 }
 
 impl SpResponseExt for SpResponse {
@@ -434,6 +436,17 @@ impl SpResponseExt for SpResponse {
             Self::Error(err) => Err(CommunicationError::SpError(err)),
             other => Err(CommunicationError::BadResponseType {
                 expected: response_kind_names::COMPONENT_SET_ACTIVE_SLOT_ACK,
+                got: other.name(),
+            }),
+        }
+    }
+
+    fn expect_send_host_nmi_ack(self) -> Result<()> {
+        match self {
+            Self::SendHostNmiAck => Ok(()),
+            Self::Error(err) => Err(CommunicationError::SpError(err)),
+            other => Err(CommunicationError::BadResponseType {
+                expected: response_kind_names::SP_STATE,
                 got: other.name(),
             }),
         }

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -42,6 +42,8 @@ pub(crate) trait SpResponseExt {
 
     fn expect_serial_console_detach_ack(self) -> Result<()>;
 
+    fn expect_serial_console_break_ack(self) -> Result<()>;
+
     fn expect_sp_update_prepare_ack(self) -> Result<()>;
 
     fn expect_component_update_prepare_ack(self) -> Result<()>;
@@ -253,6 +255,17 @@ impl SpResponseExt for SpResponse {
     fn expect_serial_console_detach_ack(self) -> Result<()> {
         match self {
             Self::SerialConsoleDetachAck => Ok(()),
+            Self::Error(err) => Err(CommunicationError::SpError(err)),
+            other => Err(CommunicationError::BadResponseType {
+                expected: response_kind_names::SP_STATE,
+                got: other.name(),
+            }),
+        }
+    }
+
+    fn expect_serial_console_break_ack(self) -> Result<()> {
+        match self {
+            Self::SerialConsoleBreakAck => Ok(()),
             Self::Error(err) => Err(CommunicationError::SpError(err)),
             other => Err(CommunicationError::BadResponseType {
                 expected: response_kind_names::SP_STATE,

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -103,6 +103,9 @@ impl SpResponseExt for SpResponse {
             Self::SerialConsoleDetachAck => {
                 response_kind_names::SERIAL_CONSOLE_DETACH_ACK
             }
+            Self::SerialConsoleBreakAck => {
+                response_kind_names::SERIAL_CONSOLE_BREAK_ACK
+            }
             Self::SpUpdatePrepareAck => {
                 response_kind_names::SP_UPDATE_PREPARE_ACK
             }
@@ -131,6 +134,7 @@ impl SpResponseExt for SpResponse {
             Self::ComponentSetActiveSlotAck => {
                 response_kind_names::COMPONENT_SET_ACTIVE_SLOT_ACK
             }
+            Self::SendHostNmiAck => response_kind_names::SEND_HOST_NMI_ACK,
         }
     }
 
@@ -440,6 +444,8 @@ mod response_kind_names {
         "serial_console_write_ack";
     pub(super) const SERIAL_CONSOLE_DETACH_ACK: &str =
         "serial_console_detach_ack";
+    pub(super) const SERIAL_CONSOLE_BREAK_ACK: &str =
+        "serial_console_break_ack";
     pub(super) const SP_UPDATE_PREPARE_ACK: &str = "sp_update_prepare_ack";
     pub(super) const COMPONENT_UPDATE_PREPARE_ACK: &str =
         "component_update_prepare_ack";
@@ -459,4 +465,5 @@ mod response_kind_names {
     pub(super) const COMPONENT_ACTIVE_SLOT: &str = "component_active_slot";
     pub(super) const COMPONENT_SET_ACTIVE_SLOT_ACK: &str =
         "component_set_active_slot_ack";
+    pub(super) const SEND_HOST_NMI_ACK: &str = "send_host_nmi_ack";
 }


### PR DESCRIPTION
This also adds UART break to the console, using the same key (Ctrl-A Ctrl-\) as `picocom`.

Needs to be tested on real hardware!

Closes https://github.com/oxidecomputer/hubris/issues/1068 and #51 once complete

TODO:
- [x] Plumb the GPIO NMI through `faux-mgs`