### PR TITLE
Send periodic keepalive packets while attached to the serial console

### DIFF
--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -11,6 +11,7 @@ pub mod tlv;
 
 use core::fmt;
 use core::str;
+use core::time::Duration;
 use serde::Deserialize;
 use serde::Serialize;
 use static_assertions::const_assert;
@@ -22,6 +23,14 @@ pub use hubpack::{deserialize, serialize, SerializedSize};
 // direction.
 pub use mgs_to_sp::*;
 pub use sp_to_mgs::*;
+
+/// The SP should detach an attached serial console client if it has not heard
+/// from it in this long (based on the assumption that it has gone away without
+/// sending an explicit detach).
+///
+/// Clients should send data or keepalive packets more frequently than this
+/// timeout to avoid being detached.
+pub const SERIAL_CONSOLE_IDLE_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Maximum size in bytes for a serialized message.
 pub const MAX_SERIALIZED_SIZE: usize = 1024;

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -124,6 +124,8 @@ pub enum MgsRequest {
     ReadCaboose {
         key: [u8; 4],
     },
+
+    SerialConsoleKeepAlive,
 }
 
 #[derive(

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -214,6 +214,12 @@ pub trait SpHandler {
         port: SpPort,
     ) -> Result<(), SpError>;
 
+    fn serial_console_keepalive(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+    ) -> Result<(), SpError>;
+
     fn serial_console_break(
         &mut self,
         sender: SocketAddrV6,
@@ -749,6 +755,9 @@ fn handle_mgs_request<H: SpHandler>(
         MgsRequest::SerialConsoleDetach => handler
             .serial_console_detach(sender, port)
             .map(|()| SpResponse::SerialConsoleDetachAck),
+        MgsRequest::SerialConsoleKeepAlive => handler
+            .serial_console_keepalive(sender, port)
+            .map(|()| SpResponse::SerialConsoleKeepAliveAck),
         MgsRequest::SerialConsoleBreak => handler
             .serial_console_break(sender, port)
             .map(|()| SpResponse::SerialConsoleBreakAck),
@@ -1036,6 +1045,14 @@ mod tests {
         }
 
         fn serial_console_detach(
+            &mut self,
+            _sender: SocketAddrV6,
+            _port: SpPort,
+        ) -> Result<(), SpError> {
+            unimplemented!()
+        }
+
+        fn serial_console_keepalive(
             &mut self,
             _sender: SocketAddrV6,
             _port: SpPort,

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -104,6 +104,8 @@ pub enum SpResponse {
 
     /// The packet contains trailing caboose data
     CabooseValue,
+
+    SerialConsoleKeepAliveAck,
 }
 
 /// Identifier for one of of an SP's KSZ8463 management-network-facing ports.

--- a/gateway-messages/tests/versioning/v2.rs
+++ b/gateway-messages/tests/versioning/v2.rs
@@ -388,6 +388,10 @@ fn mgs_request() {
     let request = MgsRequest::ReadCaboose { key: [1, 2, 3, 4] };
     let expected = &[31, 1, 2, 3, 4];
     assert_serialized(&mut out, expected, &request);
+
+    let request = MgsRequest::SerialConsoleKeepAlive;
+    let expected = &[32];
+    assert_serialized(&mut out, expected, &request);
 }
 
 #[test]
@@ -1011,5 +1015,9 @@ fn sp_response() {
 
     let response = SpResponse::CabooseValue;
     let expected = &[31];
+    assert_serialized(&mut out, expected, &response);
+
+    let response = SpResponse::SerialConsoleKeepAliveAck;
+    let expected = &[32];
     assert_serialized(&mut out, expected, &response);
 }

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -42,6 +42,8 @@ pub(crate) trait SpResponseExt {
 
     fn expect_serial_console_detach_ack(self) -> Result<()>;
 
+    fn expect_serial_console_keepalive_ack(self) -> Result<()>;
+
     fn expect_serial_console_break_ack(self) -> Result<()>;
 
     fn expect_sp_update_prepare_ack(self) -> Result<()>;
@@ -112,6 +114,9 @@ impl SpResponseExt for SpResponse {
             }
             Self::SerialConsoleDetachAck => {
                 response_kind_names::SERIAL_CONSOLE_DETACH_ACK
+            }
+            Self::SerialConsoleKeepAliveAck => {
+                response_kind_names::SERIAL_CONSOLE_KEEPALIVE_ACK
             }
             Self::SerialConsoleBreakAck => {
                 response_kind_names::SERIAL_CONSOLE_BREAK_ACK
@@ -248,7 +253,7 @@ impl SpResponseExt for SpResponse {
             Self::SerialConsoleAttachAck => Ok(()),
             Self::Error(err) => Err(CommunicationError::SpError(err)),
             other => Err(CommunicationError::BadResponseType {
-                expected: response_kind_names::SP_STATE,
+                expected: response_kind_names::SERIAL_CONSOLE_ATTACH_ACK,
                 got: other.name(),
             }),
         }
@@ -261,7 +266,7 @@ impl SpResponseExt for SpResponse {
             }
             Self::Error(err) => Err(CommunicationError::SpError(err)),
             other => Err(CommunicationError::BadResponseType {
-                expected: response_kind_names::SP_STATE,
+                expected: response_kind_names::SERIAL_CONSOLE_WRITE_ACK,
                 got: other.name(),
             }),
         }
@@ -272,7 +277,18 @@ impl SpResponseExt for SpResponse {
             Self::SerialConsoleDetachAck => Ok(()),
             Self::Error(err) => Err(CommunicationError::SpError(err)),
             other => Err(CommunicationError::BadResponseType {
-                expected: response_kind_names::SP_STATE,
+                expected: response_kind_names::SERIAL_CONSOLE_DETACH_ACK,
+                got: other.name(),
+            }),
+        }
+    }
+
+    fn expect_serial_console_keepalive_ack(self) -> Result<()> {
+        match self {
+            Self::SerialConsoleKeepAliveAck => Ok(()),
+            Self::Error(err) => Err(CommunicationError::SpError(err)),
+            other => Err(CommunicationError::BadResponseType {
+                expected: response_kind_names::SERIAL_CONSOLE_KEEPALIVE_ACK,
                 got: other.name(),
             }),
         }
@@ -283,7 +299,7 @@ impl SpResponseExt for SpResponse {
             Self::SerialConsoleBreakAck => Ok(()),
             Self::Error(err) => Err(CommunicationError::SpError(err)),
             other => Err(CommunicationError::BadResponseType {
-                expected: response_kind_names::SP_STATE,
+                expected: response_kind_names::SERIAL_CONSOLE_BREAK_ACK,
                 got: other.name(),
             }),
         }
@@ -516,6 +532,8 @@ mod response_kind_names {
         "serial_console_write_ack";
     pub(super) const SERIAL_CONSOLE_DETACH_ACK: &str =
         "serial_console_detach_ack";
+    pub(super) const SERIAL_CONSOLE_KEEPALIVE_ACK: &str =
+        "serial_console_keepalive_ack";
     pub(super) const SERIAL_CONSOLE_BREAK_ACK: &str =
         "serial_console_break_ack";
     pub(super) const SP_UPDATE_PREPARE_ACK: &str = "sp_update_prepare_ack";


### PR DESCRIPTION
This will allow the SP to detect unclean "disconnects" (i.e., MGS / faux-mgs died without sending a detach packet) after a timeout and stop sending serial console packets to a no-longer-present client.