### PR TITLE
New messages 'ResetComponent{Prepare,Trigger}' to allow reset of RoT

### DIFF
--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -141,6 +141,35 @@ impl From<UpdateId> for uuid::Uuid {
     }
 }
 
+/// Affect boot image selection after reset.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    SerializedSize,
+    Serialize,
+    Deserialize,
+)]
+pub enum ResetIntent {
+    /// Perform a normal reset without altering boot image selection.
+    Normal,
+    /// The selected slot is made persistent.
+    Persistent,
+    /// The selected slot is selected on the next reset without regard
+    /// to the persistent selection.
+    Transient,
+    // TODO:
+    // Reset and transition from Prod-signed to Dev-signed images.
+    // There must be a valid firmware installation before the reset is performed.
+    // When changes to boot policy are one-way,
+    // to be performed and a signed per-device per-boot session challenge
+    // must accompany the request. Details TBD.
+    ExpensiveAndIrrevocableProdToDev = 86,
+}
+
 /// Identifier for a single component managed by an SP.
 #[derive(
     Clone, Copy, PartialEq, Eq, Hash, SerializedSize, Serialize, Deserialize,

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -7,6 +7,7 @@
 use crate::ignition::TransceiverSelect;
 use crate::BadRequestReason;
 use crate::PowerState;
+use crate::ResetIntent;
 use crate::SpComponent;
 use crate::UpdateId;
 use hubpack::SerializedSize;
@@ -126,6 +127,15 @@ pub enum MgsRequest {
     },
 
     SerialConsoleKeepAlive,
+    ResetComponentPrepare {
+        component: SpComponent,
+    },
+    /// `ResetComponenthTrigger` may contain trailing raw data
+    ResetComponentTrigger {
+        component: SpComponent,
+        slot: Option<u16>,
+        intent: ResetIntent,
+    },
 }
 
 #[derive(

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -24,6 +24,7 @@ use crate::MgsError;
 use crate::MgsRequest;
 use crate::MgsResponse;
 use crate::PowerState;
+use crate::ResetIntent;
 use crate::SerializedSize;
 use crate::SpComponent;
 use crate::SpError;
@@ -358,6 +359,25 @@ pub trait SpHandler {
         &mut self,
         key: [u8; 4],
     ) -> Result<&'static [u8], SpError>;
+
+    fn reset_component_prepare(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        component: SpComponent,
+    ) -> Result<(), SpError>;
+
+    // On success, this method will return unless the reset
+    // affects the SP_ITSELF.
+    fn reset_component_trigger(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        component: SpComponent,
+        slot: Option<u16>,
+        intent: ResetIntent,
+        auth_data: &[u8],
+    ) -> Result<(), SpError>;
 }
 
 /// Handle a single incoming message.
@@ -656,7 +676,8 @@ fn handle_mgs_request<H: SpHandler>(
     let trailing_data = match &kind {
         MgsRequest::UpdateChunk(_)
         | MgsRequest::SerialConsoleWrite { .. }
-        | MgsRequest::SetIpccKeyLookupValue { .. } => leftover,
+        | MgsRequest::SetIpccKeyLookupValue { .. }
+        | MgsRequest::ResetComponentTrigger { .. } => leftover,
         _ => {
             if !leftover.is_empty() {
                 return (
@@ -852,6 +873,29 @@ fn handle_mgs_request<H: SpHandler>(
                     SpResponse::CabooseValue
                 }
             })
+        }
+        MgsRequest::ResetComponentPrepare { component } => handler
+            .reset_component_prepare(sender, port, component)
+            .map(|()| SpResponse::ResetComponentPrepareAck),
+        MgsRequest::ResetComponentTrigger { component, slot, intent } => {
+            // Until further implementations are done, only the RoT
+            // will be reset with this message. The SP forwards the reset
+            // message, and if successful, will get a timeout response.
+            // Layers above here will have to verify that the desired effects
+            // have been achieved. SP will see that timeout as success in this
+            // case, but it could also be a dropped message.
+            // In a case where the SP is reset, not some sub-component, there
+            // would be no response.
+            handler
+                .reset_component_trigger(
+                    sender,
+                    port,
+                    component,
+                    slot,
+                    intent,
+                    trailing_data,
+                )
+                .map(|()| SpResponse::ResetComponentTriggerAck)
         }
     };
 
@@ -1202,6 +1246,27 @@ mod tests {
             &mut self,
             _key: [u8; 4],
         ) -> Result<&'static [u8], SpError> {
+            unimplemented!()
+        }
+
+        fn reset_component_prepare(
+            &mut self,
+            _sender: SocketAddrV6,
+            _port: SpPort,
+            _component: SpComponent,
+        ) -> Result<(), SpError> {
+            unimplemented!()
+        }
+
+        fn reset_component_trigger(
+            &mut self,
+            _sender: SocketAddrV6,
+            _port: SpPort,
+            _component: SpComponent,
+            _slot: Option<u16>,
+            _intent: ResetIntent,
+            _auth_data: &[u8],
+        ) -> Result<(), SpError> {
             unimplemented!()
         }
     }

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -106,6 +106,8 @@ pub enum SpResponse {
     CabooseValue,
 
     SerialConsoleKeepAliveAck,
+    ResetComponentPrepareAck,
+    ResetComponentTriggerAck,
 }
 
 /// Identifier for one of of an SP's KSZ8463 management-network-facing ports.
@@ -471,6 +473,7 @@ pub enum SpError {
     ImageBoardUnknown,
     /// The new image has a `BORD` key that does not match the current image
     ImageBoardMismatch,
+    ResetComponentTriggerWithoutPrepare,
 }
 
 impl fmt::Display for SpError {
@@ -569,6 +572,9 @@ impl fmt::Display for SpError {
             }
             Self::ImageBoardMismatch => {
                 write!(f, "the image has a board that doesn't match the current image")
+            }
+            Self::ResetComponentTriggerWithoutPrepare => {
+                write!(f, "sys reset-component trigger requested without a preceding sys reset-component-prepare")
             }
         }
     }

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -31,6 +31,7 @@ use gateway_messages::Message;
 use gateway_messages::MessageKind;
 use gateway_messages::MgsRequest;
 use gateway_messages::PowerState;
+use gateway_messages::ResetIntent;
 use gateway_messages::SpComponent;
 use gateway_messages::SpError;
 use gateway_messages::SpPort;
@@ -761,6 +762,78 @@ impl SingleSp {
             response.expect_caboose_value().unwrap();
             data
         })
+    }
+
+    /// Instruct the SP that a reset_component_trigger will be coming with a
+    /// boot image selection policy setting.
+    ///
+    /// This is part of a two-phase reset process. MGS should set a
+    /// `reset_component_prepare()` followed by `reset_component_trigger()`. Internally,
+    /// `reset_component_trigger()` continues to send the reset trigger message until the
+    /// SP responds with an error that it wasn't expecting it, at which point we
+    /// assume a reset has happened. In critical situations (e.g., updates),
+    /// callers should verify through a separate channel that the operation they
+    /// needed the reset for has happened (e.g., checking the SP's version, in
+    /// the case of updates).
+    pub async fn reset_component_prepare(
+        &self,
+        component: SpComponent,
+    ) -> Result<()> {
+        debug!(
+            self.log,
+            "sending ResetComponentPrepare component:{component:?}"
+        );
+        let r = self
+            .rpc(MgsRequest::ResetComponentPrepare { component })
+            .await
+            .and_then(|(_peer, response, _data)| {
+                response
+                    .expect_sys_reset_component_prepare_ack()
+                    .map_err(Into::into)
+            });
+        debug!(self.log, "response from ResetComponentPrepare component:{component:?} is {r:?}");
+
+        r
+    }
+
+    /// Instruct the SP to reset a component.
+    ///
+    /// Only valid after a successful call to `reset_component_prepare()`.
+    pub async fn reset_component_trigger(
+        &self,
+        component: SpComponent,
+        slot: Option<u16>,
+        intent: ResetIntent,
+        auth_data: &[u8],
+    ) -> Result<()> {
+        // If we are resetting the SP itself, then reset trigger should
+        // retry until we get back an error indicating the
+        // SP wasn't expecting a reset trigger (because it has reset!).
+        // If we are resetting the RoT, the SP will send an ack.
+        // When resetting the RoT, the SP SpRot client will either
+        // timeout on a response because the RoT was reset or because the message
+        // got dropped. TODO: have this code and/or SP check a boot nonce or other
+        // information to verify that the RoT did reset.
+        let data = if !auth_data.is_empty() {
+            Some(Cursor::new(auth_data.to_vec()))
+        } else {
+            None
+        };
+        let response = rpc(
+            &self.cmds_tx,
+            MgsRequest::ResetComponentTrigger { component, slot, intent },
+            data,
+        )
+        .await;
+        match response.result {
+            Ok((_addr, response, _data)) => {
+                response.expect_sys_reset_component_trigger_ack()
+            }
+            Err(CommunicationError::SpError(
+                SpError::ResetComponentTriggerWithoutPrepare,
+            )) if component == SpComponent::SP_ITSELF => Ok(()),
+            Err(other) => Err(other),
+        }
     }
 }
 

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -83,6 +83,10 @@ pub(crate) trait SpResponseExt {
     fn expect_set_ipcc_key_lookup_value_ack(self) -> Result<()>;
 
     fn expect_caboose_value(self) -> Result<()>;
+
+    fn expect_sys_reset_component_prepare_ack(self) -> Result<()>;
+
+    fn expect_sys_reset_component_trigger_ack(self) -> Result<()>;
 }
 
 impl SpResponseExt for SpResponse {
@@ -157,6 +161,12 @@ impl SpResponseExt for SpResponse {
                 response_kind_names::SET_IPCC_KEY_LOOKUP_VALUE_ACK
             }
             Self::CabooseValue => response_kind_names::CABOOSE_VALUE,
+            Self::ResetComponentPrepareAck => {
+                response_kind_names::RESET_COMPONENT_PREPARE_ACK
+            }
+            Self::ResetComponentTriggerAck => {
+                response_kind_names::RESET_COMPONENT_TRIGGER_ACK
+            }
         }
     }
 
@@ -513,6 +523,28 @@ impl SpResponseExt for SpResponse {
             }),
         }
     }
+
+    fn expect_sys_reset_component_prepare_ack(self) -> Result<()> {
+        match self {
+            Self::ResetComponentPrepareAck => Ok(()),
+            Self::Error(err) => Err(CommunicationError::SpError(err)),
+            other => Err(CommunicationError::BadResponseType {
+                expected: response_kind_names::RESET_COMPONENT_PREPARE_ACK,
+                got: other.name(),
+            }),
+        }
+    }
+
+    fn expect_sys_reset_component_trigger_ack(self) -> Result<()> {
+        match self {
+            Self::ResetComponentTriggerAck => Ok(()),
+            Self::Error(err) => Err(CommunicationError::SpError(err)),
+            other => Err(CommunicationError::BadResponseType {
+                expected: response_kind_names::RESET_COMPONENT_TRIGGER_ACK,
+                got: other.name(),
+            }),
+        }
+    }
 }
 
 mod response_kind_names {
@@ -561,4 +593,8 @@ mod response_kind_names {
     pub(super) const SET_IPCC_KEY_LOOKUP_VALUE_ACK: &str =
         "set_ipcc_key_lookup_value_ack";
     pub(super) const CABOOSE_VALUE: &str = "caboose_value";
+    pub(super) const RESET_COMPONENT_PREPARE_ACK: &str =
+        "reset_component_prepare_ack";
+    pub(super) const RESET_COMPONENT_TRIGGER_ACK: &str =
+        "reset_component_trigger_ack";
 }


### PR DESCRIPTION
This enables RoT reset during update.

The merge will need to be coordinated with the merge of hubris merge of reset-with-intent.
The image preference after reset {None, ImageA, ImageB, TransientA, TransientB} will need to be plumbed after this.

