### PR TITLE
Revert "New messages 'ResetComponent{Prepare,Trigger}' to allow reset of RoT"

### DIFF
--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -16,7 +16,6 @@ use futures::StreamExt;
 use gateway_messages::ignition::TransceiverSelect;
 use gateway_messages::IgnitionCommand;
 use gateway_messages::PowerState;
-use gateway_messages::ResetIntent;
 use gateway_messages::SpComponent;
 use gateway_messages::StartupOptions;
 use gateway_messages::UpdateId;
@@ -52,7 +51,7 @@ struct Args {
         long,
         default_value = "info",
         value_parser = level_from_str,
-        help = "Log level for MGS client: {off,critical,error,warn,info,debug,trace}",
+        help = "Log level for MGS client",
     )]
     log_level: Level,
 
@@ -270,40 +269,6 @@ enum Command {
 
     /// Instruct the SP to reset.
     Reset,
-
-    /// Reset a component.
-    ///
-    /// This command is implemented for the component "rot" but may be
-    /// expanded to other components in the future.
-    //
-    // TODO: RoT boot image selection.
-    // TODO: revoke RoT Prod keys.
-    ResetComponent {
-        /// "rot" and "stage0" are equivalent since they are different firmware images on the same
-        /// physical part.
-        component: String,
-        #[clap(
-             default_value = "normal",
-             help = "'normal'(default) perform a simple reset of the component.{n}\
-                     'persistent' changes the CFPA image selection to `slot`.{n}\
-                     'transient' overrides the CFPA selection to `slot` for the next reset only.{n}\
-                     Selecting a slot with a lower image epoch will be refused by the RoT.",
-                     // TODO: ExpensiveAndIrrevocableProdToDev with auth_data
-             value_parser = reset_intent_from_str,
-        )]
-        intent: ResetIntent,
-
-        // RoT ImageA=0, ImageB=1
-        #[clap(
-            default_value = None,
-            help = "Image slot selection for Persistent and Transient intents",
-        )]
-        slot: Option<u16>,
-        // TODO: Authorization for ExpensiveAndIrrevocableProdToDev
-        // auth: [u8; EAIPTD_MAX_SIZE],
-        // // Path to authentication blob
-        // auth: Option<PathBuf>,
-    },
 }
 
 impl Command {
@@ -381,16 +346,6 @@ fn ignition_command_from_str(s: &str) -> Result<IgnitionCommand> {
         "power-off" => Ok(IgnitionCommand::PowerOff),
         "power-reset" => Ok(IgnitionCommand::PowerReset),
         _ => Err(anyhow!("Invalid ignition command: {s}")),
-    }
-}
-
-fn reset_intent_from_str(s: &str) -> Result<ResetIntent> {
-    match s {
-        "normal" | "n" => Ok(ResetIntent::Normal),
-        "persistent" | "p" => Ok(ResetIntent::Persistent),
-        "transient" | "t" => Ok(ResetIntent::Transient),
-        // "expensive_and_irrevocable_prod_to_dev" => Ok(ResetIntent::ExpensiveAndIrrevocableProdToDev),
-        _ => Err(anyhow!("Invalid reset intent: {s}")),
     }
 }
 
@@ -889,31 +844,6 @@ async fn run_command(
             info!(log, "SP is prepared to reset");
             sp.reset_trigger().await?;
             info!(log, "SP reset complete");
-            Ok(vec!["reset complete".to_string()])
-        }
-        // TODO: Add slot, intent, and PathBuf to auth blob
-        Command::ResetComponent {
-            component,
-            intent: _intents,
-            slot: _slot,
-        } => {
-            let sp_component = SpComponent::try_from(component.as_str())
-                .map_err(|_| anyhow!("invalid component name: {component}"))?;
-            sp.reset_component_prepare(sp_component).await?;
-            info!(
-                log,
-                "SP is repared to reset component {}",
-                component.as_str()
-            );
-            let auth_data = Vec::new(); // TODO: allow actual authentication blobs.
-            sp.reset_component_trigger(
-                sp_component,
-                None,
-                ResetIntent::Normal,
-                &auth_data,
-            )
-            .await?;
-            info!(log, "SP reset component {} complete", component.as_str());
             Ok(vec!["reset complete".to_string()])
         }
         Command::SendHostNmi => {

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -141,35 +141,6 @@ impl From<UpdateId> for uuid::Uuid {
     }
 }
 
-/// Affect boot image selection after reset.
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Hash,
-    SerializedSize,
-    Serialize,
-    Deserialize,
-)]
-pub enum ResetIntent {
-    /// Perform a normal reset without altering boot image selection.
-    Normal,
-    /// The selected slot is made persistent.
-    Persistent,
-    /// The selected slot is selected on the next reset without regard
-    /// to the persistent selection.
-    Transient,
-    // TODO:
-    // Reset and transition from Prod-signed to Dev-signed images.
-    // There must be a valid firmware installation before the reset is performed.
-    // When changes to boot policy are one-way,
-    // to be performed and a signed per-device per-boot session challenge
-    // must accompany the request. Details TBD.
-    ExpensiveAndIrrevocableProdToDev = 86,
-}
-
 /// Identifier for a single component managed by an SP.
 #[derive(
     Clone, Copy, PartialEq, Eq, Hash, SerializedSize, Serialize, Deserialize,

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -7,7 +7,6 @@
 use crate::ignition::TransceiverSelect;
 use crate::BadRequestReason;
 use crate::PowerState;
-use crate::ResetIntent;
 use crate::SpComponent;
 use crate::UpdateId;
 use hubpack::SerializedSize;
@@ -127,15 +126,6 @@ pub enum MgsRequest {
     },
 
     SerialConsoleKeepAlive,
-    ResetComponentPrepare {
-        component: SpComponent,
-    },
-    /// `ResetComponenthTrigger` may contain trailing raw data
-    ResetComponentTrigger {
-        component: SpComponent,
-        slot: Option<u16>,
-        intent: ResetIntent,
-    },
 }
 
 #[derive(

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -106,8 +106,6 @@ pub enum SpResponse {
     CabooseValue,
 
     SerialConsoleKeepAliveAck,
-    ResetComponentPrepareAck,
-    ResetComponentTriggerAck,
 }
 
 /// Identifier for one of of an SP's KSZ8463 management-network-facing ports.
@@ -473,7 +471,6 @@ pub enum SpError {
     ImageBoardUnknown,
     /// The new image has a `BORD` key that does not match the current image
     ImageBoardMismatch,
-    ResetComponentTriggerWithoutPrepare,
 }
 
 impl fmt::Display for SpError {
@@ -572,9 +569,6 @@ impl fmt::Display for SpError {
             }
             Self::ImageBoardMismatch => {
                 write!(f, "the image has a board that doesn't match the current image")
-            }
-            Self::ResetComponentTriggerWithoutPrepare => {
-                write!(f, "sys reset-component trigger requested without a preceding sys reset-component-prepare")
             }
         }
     }

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -31,7 +31,6 @@ use gateway_messages::Message;
 use gateway_messages::MessageKind;
 use gateway_messages::MgsRequest;
 use gateway_messages::PowerState;
-use gateway_messages::ResetIntent;
 use gateway_messages::SpComponent;
 use gateway_messages::SpError;
 use gateway_messages::SpPort;
@@ -762,78 +761,6 @@ impl SingleSp {
             response.expect_caboose_value().unwrap();
             data
         })
-    }
-
-    /// Instruct the SP that a reset_component_trigger will be coming with a
-    /// boot image selection policy setting.
-    ///
-    /// This is part of a two-phase reset process. MGS should set a
-    /// `reset_component_prepare()` followed by `reset_component_trigger()`. Internally,
-    /// `reset_component_trigger()` continues to send the reset trigger message until the
-    /// SP responds with an error that it wasn't expecting it, at which point we
-    /// assume a reset has happened. In critical situations (e.g., updates),
-    /// callers should verify through a separate channel that the operation they
-    /// needed the reset for has happened (e.g., checking the SP's version, in
-    /// the case of updates).
-    pub async fn reset_component_prepare(
-        &self,
-        component: SpComponent,
-    ) -> Result<()> {
-        debug!(
-            self.log,
-            "sending ResetComponentPrepare component:{component:?}"
-        );
-        let r = self
-            .rpc(MgsRequest::ResetComponentPrepare { component })
-            .await
-            .and_then(|(_peer, response, _data)| {
-                response
-                    .expect_sys_reset_component_prepare_ack()
-                    .map_err(Into::into)
-            });
-        debug!(self.log, "response from ResetComponentPrepare component:{component:?} is {r:?}");
-
-        r
-    }
-
-    /// Instruct the SP to reset a component.
-    ///
-    /// Only valid after a successful call to `reset_component_prepare()`.
-    pub async fn reset_component_trigger(
-        &self,
-        component: SpComponent,
-        slot: Option<u16>,
-        intent: ResetIntent,
-        auth_data: &[u8],
-    ) -> Result<()> {
-        // If we are resetting the SP itself, then reset trigger should
-        // retry until we get back an error indicating the
-        // SP wasn't expecting a reset trigger (because it has reset!).
-        // If we are resetting the RoT, the SP will send an ack.
-        // When resetting the RoT, the SP SpRot client will either
-        // timeout on a response because the RoT was reset or because the message
-        // got dropped. TODO: have this code and/or SP check a boot nonce or other
-        // information to verify that the RoT did reset.
-        let data = if !auth_data.is_empty() {
-            Some(Cursor::new(auth_data.to_vec()))
-        } else {
-            None
-        };
-        let response = rpc(
-            &self.cmds_tx,
-            MgsRequest::ResetComponentTrigger { component, slot, intent },
-            data,
-        )
-        .await;
-        match response.result {
-            Ok((_addr, response, _data)) => {
-                response.expect_sys_reset_component_trigger_ack()
-            }
-            Err(CommunicationError::SpError(
-                SpError::ResetComponentTriggerWithoutPrepare,
-            )) if component == SpComponent::SP_ITSELF => Ok(()),
-            Err(other) => Err(other),
-        }
     }
 }
 

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -83,10 +83,6 @@ pub(crate) trait SpResponseExt {
     fn expect_set_ipcc_key_lookup_value_ack(self) -> Result<()>;
 
     fn expect_caboose_value(self) -> Result<()>;
-
-    fn expect_sys_reset_component_prepare_ack(self) -> Result<()>;
-
-    fn expect_sys_reset_component_trigger_ack(self) -> Result<()>;
 }
 
 impl SpResponseExt for SpResponse {
@@ -161,12 +157,6 @@ impl SpResponseExt for SpResponse {
                 response_kind_names::SET_IPCC_KEY_LOOKUP_VALUE_ACK
             }
             Self::CabooseValue => response_kind_names::CABOOSE_VALUE,
-            Self::ResetComponentPrepareAck => {
-                response_kind_names::RESET_COMPONENT_PREPARE_ACK
-            }
-            Self::ResetComponentTriggerAck => {
-                response_kind_names::RESET_COMPONENT_TRIGGER_ACK
-            }
         }
     }
 
@@ -523,28 +513,6 @@ impl SpResponseExt for SpResponse {
             }),
         }
     }
-
-    fn expect_sys_reset_component_prepare_ack(self) -> Result<()> {
-        match self {
-            Self::ResetComponentPrepareAck => Ok(()),
-            Self::Error(err) => Err(CommunicationError::SpError(err)),
-            other => Err(CommunicationError::BadResponseType {
-                expected: response_kind_names::RESET_COMPONENT_PREPARE_ACK,
-                got: other.name(),
-            }),
-        }
-    }
-
-    fn expect_sys_reset_component_trigger_ack(self) -> Result<()> {
-        match self {
-            Self::ResetComponentTriggerAck => Ok(()),
-            Self::Error(err) => Err(CommunicationError::SpError(err)),
-            other => Err(CommunicationError::BadResponseType {
-                expected: response_kind_names::RESET_COMPONENT_TRIGGER_ACK,
-                got: other.name(),
-            }),
-        }
-    }
 }
 
 mod response_kind_names {
@@ -593,8 +561,4 @@ mod response_kind_names {
     pub(super) const SET_IPCC_KEY_LOOKUP_VALUE_ACK: &str =
         "set_ipcc_key_lookup_value_ack";
     pub(super) const CABOOSE_VALUE: &str = "caboose_value";
-    pub(super) const RESET_COMPONENT_PREPARE_ACK: &str =
-        "reset_component_prepare_ack";
-    pub(super) const RESET_COMPONENT_TRIGGER_ACK: &str =
-        "reset_component_trigger_ack";
 }


### PR DESCRIPTION
Reverts oxidecomputer/management-gateway-service#70 which needs to go in after https://github.com/oxidecomputer/hubris/pull/1233