### PR TITLE
Add --json output flag to faux-mgs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,50 @@ default-members = [
     "gateway-sp-comms",
 ]
 resolver = "2"
+
+[workspace.dependencies]
+# TODO point back to crates.io after a new release
+hubpack = { git = "https://github.com/cbiffle/hubpack" }
+
+# TODO: Replace with real nix after https://github.com/nix-rust/nix/pull/1973 is
+# published to crates.io
+nix = { git = "https://github.com/jgallagher/nix", branch = "r0.26-illumos" }
+
+tlvc = {git = "https://github.com/oxidecomputer/tlvc.git"}
+
+anyhow = "1.0"
+async-trait = "0.1"
+backoff = { version = "0.4.0", features = ["tokio"] }
+bitflags = "1.3.2"
+clap = { version = "4.0", features = ["derive"] }
+futures = "0.3.24"
+fxhash = "0.2.1"
+glob = "0.3.1"
+hex = "0.4.3"
+lru-cache = "0.1.2"
+once_cell = "1.15.0"
+serde = { version = "1.0", features = ["derive"] }
+serde-big-array = "0.5.0"
+serde_json = "1.0.95"
+serde_repr = { version = "0.1" }
+sha2 = "0.10"
+slog = { version = "2.7", features = ["max_level_trace", "release_max_level_trace"] }
+slog-async = "2.6"
+slog-term = "2.9"
+smoltcp = { version = "0.8", default-features = false, features = ["proto-ipv6"] }
+socket2 = "0.5.1"
+static_assertions = "1.1.0"
+string_cache = "0.8.4"
+termios = "0.3"
+thiserror = "1.0.37"
+tokio = { version = "1.21", features = ["full"] }
+tokio-stream = { version = "0.1", features = ["fs"] }
+tokio-util = { version = "0.7", features = ["compat"] }
+usdt = "0.3.1"
+uuid = { version = "1.1", default-features = false }
+version_check = "0.9.4"
+zerocopy = "0.6.1"
+zip = { version = "0.6.2", default-features = false, features = ["deflate","bzip2"] }
+
+gateway-messages.path = "gateway-messages"
+gateway-sp-comms.path = "gateway-sp-comms"

--- a/faux-mgs/Cargo.toml
+++ b/faux-mgs/Cargo.toml
@@ -5,23 +5,25 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1"
-clap = { version = "4.0", features = ["derive"] }
-futures = "0.3"
-glob = "0.3.1"
-hex = "0.4"
-nix = "0.26.2"
-sha2 = "0.10"
-slog = { version = "2.7", features = ["max_level_trace", "release_max_level_trace"] }
-slog-async = "2.6"
-slog-term = "2.9"
-termios = "0.3"
-thiserror = "1.0"
-tokio = { version = "1.21", features = ["full"] }
-tokio-stream = { version = "0.1", features = ["fs"] }
-tokio-util = { version = "0.7", features = ["compat"] }
-uuid = { version = "1.1", features = ["v4"] }
+anyhow.workspace = true
+async-trait.workspace = true
+clap.workspace = true
+futures.workspace = true
+glob.workspace = true
+hex.workspace = true
+nix.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+slog.workspace = true
+slog-async.workspace = true
+slog-term.workspace = true
+termios.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tokio-stream.workspace = true
+tokio-util.workspace = true
+uuid = { workspace = true, features = ["std", "v4"] }
 
-gateway-messages = { path = "../gateway-messages", features = ["std"] }
-gateway-sp-comms = { path = "../gateway-sp-comms" }
+gateway-messages = { workspace = true, features = ["std"] }
+gateway-sp-comms.workspace = true

--- a/gateway-messages/Cargo.toml
+++ b/gateway-messages/Cargo.toml
@@ -5,19 +5,17 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-bitflags = "1.3.2"
-hubpack = "0.1"
-serde = { version = "1.0.145", default-features = false, features = ["derive"] }
-serde_repr = { version = "0.1" }
-static_assertions = "1.1.0"
-uuid = { version = "1.1", default-features = false }
-zerocopy = "0.6.1"
+bitflags.workspace = true
+hubpack.workspace = true
+serde.workspace = true
+serde_repr.workspace = true
+smoltcp = { workspace = true, optional = true }
+static_assertions.workspace = true
+uuid.workspace = true
+zerocopy.workspace = true
 
-[dependencies.smoltcp]
-version = "0.8"
-default-features = false
-features = ["proto-ipv6"]
-optional = true
+[dev-dependencies]
+serde_json.workspace = true
 
 [features]
 default = ["smoltcp"]

--- a/gateway-messages/src/tlv.rs
+++ b/gateway-messages/src/tlv.rs
@@ -172,7 +172,7 @@ mod tests {
         let (tag, decoded_value, rest) = decode(&buf[..n]).unwrap();
         assert_eq!(tag, TAG);
         assert_eq!(decoded_value, value);
-        assert_eq!(rest, &[]);
+        assert_eq!(rest, &[] as &[u8]);
 
         // Give decode the full buffer.
         let (tag, decoded_value, rest) = decode(&buf).unwrap();
@@ -237,7 +237,10 @@ mod tests {
 
         assert_eq!(
             n,
-            tag_values.iter().map(|(_tag, value)| tlv_len(value.len())).sum()
+            tag_values
+                .iter()
+                .map(|(_tag, value)| tlv_len(value.len()))
+                .sum::<usize>()
         );
 
         let decoded =

--- a/gateway-sp-comms/Cargo.toml
+++ b/gateway-sp-comms/Cargo.toml
@@ -5,35 +5,30 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-async-trait = "0.1"
-backoff = { version = "0.4.0", features = ["tokio"] }
-futures = "0.3.24"
-fxhash = "0.2.1"
-hex = "0.4.3"
-hubpack = "0.1"
-lru-cache = "0.1.2"
-# TODO: Replace with real nix after https://github.com/nix-rust/nix/pull/1973 is
-# merged / released
-nix = { git = "https://github.com/jgallagher/nix", branch = "r0.26-illumos" }
-once_cell = "1.15.0"
-serde = { version = "1.0", features = ["derive"] }
-serde-big-array = "0.5.0"
-slog = "2.7"
-socket2 = "0.5.1"
-string_cache = "0.8.4"
-thiserror = "1.0.37"
-tlvc = {git = "https://github.com/oxidecomputer/tlvc.git"}
-usdt = "0.3.1"
-uuid = "1.1.0"
-zip = { version = "0.6.2", default-features = false, features = ["deflate","bzip2"] }
+async-trait.workspace = true
+backoff.workspace = true
+futures.workspace = true
+fxhash.workspace = true
+hex.workspace = true
+hubpack.workspace = true
+nix.workspace = true
+lru-cache.workspace = true
+once_cell.workspace = true
+serde.workspace = true
+serde-big-array.workspace = true
+slog.workspace = true
+socket2.workspace = true
+string_cache.workspace = true
+thiserror.workspace = true
+tlvc.workspace = true
+tokio.workspace = true
+usdt.workspace = true
+uuid.workspace = true
+zip.workspace = true
 
-gateway-messages = { path = "../gateway-messages", features = ["std"] }
-
-[dependencies.tokio]
-version = "1.21"
-features = [ "full" ]
+gateway-messages.workspace = true
 
 # This is required for the build.rs script to check for an appropriate compiler
 # version so that `usdt` can be built on stable rust.
 [build-dependencies]
-version_check = "0.9.4"
+version_check.workspace = true

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -44,6 +44,7 @@ use gateway_messages::SwitchDuration;
 use gateway_messages::TlvPage;
 use gateway_messages::UpdateStatus;
 use gateway_messages::MIN_TRAILING_DATA_LEN;
+use serde::Serialize;
 use slog::debug;
 use slog::error;
 use slog::info;
@@ -102,12 +103,12 @@ pub struct HostPhase2Request {
     pub received: Instant,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct SpInventory {
     pub devices: Vec<SpDevice>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct SpDevice {
     pub component: SpComponent,
     pub device: String,


### PR DESCRIPTION
`faux-mgs` now accepts `--json` (or `--json=pretty` if you want indentation and lots of newlines). If passed, stdout will contain a single JSON object with a key for each `--interface` passed to `faux-mgs`. In a benchtop faux-mgs invocation this may be a little silly (e.g., to have an object with a key `axf0`), but it's aimed at usage within a switch zone where we might want to say `faux-mgs --interface 'gimlet*' state` to fetch the state from all gimlets.

Each interface key will have an object value containing either an `Ok` or `Err` key. If the `Err` key exists, its value is a string; e.g.,

```json
{
  "eth0": {
    "Err": "no SP discovered"
  }
}
```

If the key is `Ok`, the structure of its value is dependent on the command that was run. For many commands, the returned structure matches some `serde::{Serialize, Deserialize}`-implementing type in `gateway-messages`; e.g., the type of the value for `Ok` printed for `faux-mgs --json ... state` is a serialized [`SpState`](https://github.com/oxidecomputer/management-gateway-service/blob/2dcc63c645005a7184ba754b5c42c341a0777c66/gateway-messages/src/sp_to_mgs.rs#L148-L160).

@jclulow I tapped you for review, but I'm mostly interested in your review of the _output_ of `faux-mgs` on this branch. (You're welcome to look at the code but it's largely uninteresting IMO.) Most of the types being serialized here have previously only been serialized with `hubpack`, and some may look strange in JSON. If we care about that I can go through and tidy some of them up, or we can merge this more or less as-is and make cleanup tweaks over time as this mode gets used.

Fixes #35.