### PR TITLE
Don't panic when sending keepalives to out-of-date SPs

### DIFF
--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -492,6 +492,7 @@ async fn main() -> Result<()> {
                 imap,
                 omap,
                 uart_logfile,
+                log,
             )
             .await?;
 


### PR DESCRIPTION
https://github.com/oxidecomputer/hubris/pull/1214 added support for console keepalive messages on the SP; however, we still have some SPs running older builds. This tweaks faux-mgs's console loop to warn if the SP doesn't understand the keepalive message instead of returning an error (which leads to a panic, as returning an error means we're no longer accepting input).