### PR TITLE
Implement system LED control

### DIFF
--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -307,7 +307,9 @@ enum Command {
 
 #[derive(Subcommand, Debug, Clone)]
 enum LedCommand {
+    /// Turns the LED on
     On,
+    /// Turns the LED off
     Off,
 }
 

--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -311,6 +311,8 @@ enum LedCommand {
     On,
     /// Turns the LED off
     Off,
+    /// Enables blinking
+    Blink,
 }
 
 impl Command {
@@ -958,6 +960,7 @@ async fn run_command(
                 ComponentAction::Led(match cmd {
                     LedCommand::On => LedComponentAction::TurnOn,
                     LedCommand::Off => LedComponentAction::TurnOff,
+                    LedCommand::Blink => LedComponentAction::Blink,
                 }),
             )
             .await?;

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -63,7 +63,7 @@ pub const MAX_SERIALIZED_SIZE: usize = 1024;
 /// for more detail and discussion.
 pub mod version {
     pub const MIN: u32 = 2;
-    pub const CURRENT: u32 = 2;
+    pub const CURRENT: u32 = 3;
 }
 
 #[derive(
@@ -203,6 +203,9 @@ impl SpComponent {
     /// Prefix for devices that are identified generically by index (e.g.,
     /// `dev-17`).
     pub const GENERIC_DEVICE_PREFIX: &'static str = "dev-";
+
+    /// System attention LED (of which there is one per system)
+    pub const SYSTEM_LED: Self = Self { id: *b"system-led\0\0\0\0\0\0" };
 
     /// Interpret the component name as a human-readable string.
     ///

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -144,6 +144,11 @@ pub enum MgsRequest {
         slot: SlotId,
         duration: SwitchDuration,
     },
+
+    ComponentAction {
+        component: SpComponent,
+        action: ComponentAction,
+    },
 }
 
 #[derive(
@@ -208,6 +213,22 @@ pub struct ComponentUpdatePrepare {
     pub total_size: u32,
     // TODO auth info? checksum/digest?
     // TODO should we inline the first chunk?
+}
+
+#[derive(
+    Copy, Clone, Serialize, SerializedSize, Deserialize, PartialEq, Eq, Debug,
+)]
+pub enum ComponentAction {
+    Led(LedComponentAction),
+}
+
+/// Actions for LED components, i.e. components with `IS_AN_LED` set
+#[derive(
+    Copy, Clone, Serialize, SerializedSize, Deserialize, PartialEq, Eq, Debug,
+)]
+pub enum LedComponentAction {
+    TurnOn,
+    TurnOff,
 }
 
 #[derive(

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -229,6 +229,7 @@ pub enum ComponentAction {
 pub enum LedComponentAction {
     TurnOn,
     TurnOff,
+    Blink,
 }
 
 #[derive(

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -222,7 +222,7 @@ pub enum ComponentAction {
     Led(LedComponentAction),
 }
 
-/// Actions for LED components, i.e. components with `IS_AN_LED` set
+/// Actions for LED components, i.e. components with `IS_LED` set
 #[derive(
     Copy, Clone, Serialize, SerializedSize, Deserialize, PartialEq, Eq, Debug,
 )]

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -9,6 +9,7 @@ use crate::ignition::LinkEvents;
 use crate::tlv;
 use crate::version;
 use crate::BadRequestReason;
+use crate::ComponentAction;
 use crate::ComponentDetails;
 use crate::ComponentUpdatePrepare;
 use crate::DeviceCapabilities;
@@ -295,6 +296,13 @@ pub trait SpHandler {
         component: SpComponent,
         slot: u16,
         persist: bool,
+    ) -> Result<(), SpError>;
+
+    fn component_action(
+        &mut self,
+        sender: SocketAddrV6,
+        component: SpComponent,
+        action: ComponentAction,
     ) -> Result<(), SpError>;
 
     fn get_startup_options(
@@ -878,6 +886,9 @@ fn handle_mgs_request<H: SpHandler>(
         MgsRequest::SwitchDefaultImage { component, slot, duration } => handler
             .switch_default_image(sender, port, component, slot, duration)
             .map(|()| SpResponse::SwitchDefaultImageAck),
+        MgsRequest::ComponentAction { component, action } => handler
+            .component_action(sender, component, action)
+            .map(|()| SpResponse::ComponentActionAck),
     };
 
     let response = match result {
@@ -1185,6 +1196,15 @@ mod tests {
             _component: SpComponent,
             _slot: u16,
             _persist: bool,
+        ) -> Result<(), SpError> {
+            unimplemented!()
+        }
+
+        fn component_action(
+            &mut self,
+            _sender: SocketAddrV6,
+            _component: SpComponent,
+            _action: ComponentAction,
         ) -> Result<(), SpError> {
             unimplemented!()
         }

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -109,6 +109,7 @@ pub enum SpResponse {
     ResetComponentPrepareAck,
     ResetComponentTriggerAck,
     SwitchDefaultImageAck,
+    ComponentActionAck,
 }
 
 /// Identifier for one of of an SP's KSZ8463 management-network-facing ports.
@@ -298,6 +299,7 @@ bitflags! {
         const UPDATEABLE = 1 << 0;
         const HAS_MEASUREMENT_CHANNELS = 1 << 1;
         const HAS_SERIAL_CONSOLE = 1 << 2;
+        const IS_LED = 1 << 3;
         // MGS has a placeholder API for powering off an individual component;
         // do we want to keep that? If so, add a bit for "can be powered on and
         // off".

--- a/gateway-messages/tests/versioning/mod.rs
+++ b/gateway-messages/tests/versioning/mod.rs
@@ -4,4 +4,16 @@
 
 // Copyright 2023 Oxide Computer Company
 
+use serde::Serialize;
+
 mod v2;
+mod v3;
+
+pub fn assert_serialized(
+    out: &mut [u8],
+    expected: &[u8],
+    item: &impl Serialize,
+) {
+    let n = gateway_messages::serialize(out, item).unwrap();
+    assert_eq!(expected, &out[..n]);
+}

--- a/gateway-messages/tests/versioning/v2.rs
+++ b/gateway-messages/tests/versioning/v2.rs
@@ -59,12 +59,8 @@ use gateway_messages::UpdateInProgressStatus;
 use gateway_messages::UpdatePreparationProgress;
 use gateway_messages::UpdatePreparationStatus;
 use gateway_messages::UpdateStatus;
-use serde::Serialize;
 
-fn assert_serialized(out: &mut [u8], expected: &[u8], item: &impl Serialize) {
-    let n = gateway_messages::serialize(out, item).unwrap();
-    assert_eq!(expected, &out[..n]);
-}
+use super::assert_serialized;
 
 // This test covers the high-level `Message`, `Header`, and `MessageKind` types.
 // It does not cover all possible request/response variants that live inside

--- a/gateway-messages/tests/versioning/v3.rs
+++ b/gateway-messages/tests/versioning/v3.rs
@@ -31,14 +31,21 @@ fn mgs_request() {
         component: SpComponent::SYSTEM_LED,
         action: ComponentAction::Led(LedComponentAction::TurnOn),
     };
-    let expected = b"\x21system-led\0\0\0\0\0\0\0\0";
+    let expected = b"\x24system-led\0\0\0\0\0\0\0\0";
     assert_serialized(&mut out, expected, &request);
 
     let request = MgsRequest::ComponentAction {
         component: SpComponent::SYSTEM_LED,
         action: ComponentAction::Led(LedComponentAction::TurnOff),
     };
-    let expected = b"\x21system-led\0\0\0\0\0\0\0\x01";
+    let expected = b"\x24system-led\0\0\0\0\0\0\0\x01";
+    assert_serialized(&mut out, expected, &request);
+
+    let request = MgsRequest::ComponentAction {
+        component: SpComponent::SYSTEM_LED,
+        action: ComponentAction::Led(LedComponentAction::Blink),
+    };
+    let expected = b"\x24system-led\0\0\0\0\0\0\0\x02";
     assert_serialized(&mut out, expected, &request);
 }
 
@@ -46,6 +53,6 @@ fn mgs_request() {
 fn sp_response() {
     let mut out = [0; SpResponse::MAX_SIZE];
     let response = SpResponse::ComponentActionAck;
-    let expected = &[33];
+    let expected = &[36];
     assert_serialized(&mut out, expected, &response);
 }

--- a/gateway-messages/tests/versioning/v3.rs
+++ b/gateway-messages/tests/versioning/v3.rs
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2023 Oxide Computer Company
+
+//! The tests in this module check that the serialized form of messages from MGS
+//! protocol version 3 have not changed.
+//!
+//! If a test in this module fails, _do not change the test_! This means you
+//! have changed, deleted, or reordered an existing message type or enum
+//! variant, and you should revert that change. This will remain true until we
+//! bump the `version::MIN` to a value higher than 3, at which point these tests
+//! can be removed as we will stop supporting v3.
+
+use gateway_messages::ComponentAction;
+use gateway_messages::LedComponentAction;
+use gateway_messages::MgsRequest;
+use gateway_messages::SerializedSize;
+use gateway_messages::SpComponent;
+use gateway_messages::SpResponse;
+
+use super::assert_serialized;
+
+// This test covers the ComponentAction message added in v3.
+#[test]
+fn mgs_request() {
+    let mut out = [0; MgsRequest::MAX_SIZE];
+
+    let request = MgsRequest::ComponentAction {
+        component: SpComponent::SYSTEM_LED,
+        action: ComponentAction::Led(LedComponentAction::TurnOn),
+    };
+    let expected = b"\x21system-led\0\0\0\0\0\0\0\0";
+    assert_serialized(&mut out, expected, &request);
+
+    let request = MgsRequest::ComponentAction {
+        component: SpComponent::SYSTEM_LED,
+        action: ComponentAction::Led(LedComponentAction::TurnOff),
+    };
+    let expected = b"\x21system-led\0\0\0\0\0\0\0\x01";
+    assert_serialized(&mut out, expected, &request);
+}
+
+#[test]
+fn sp_response() {
+    let mut out = [0; SpResponse::MAX_SIZE];
+    let response = SpResponse::ComponentActionAck;
+    let expected = &[33];
+    assert_serialized(&mut out, expected, &response);
+}

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -20,6 +20,7 @@ use gateway_messages::ignition::LinkEvents;
 use gateway_messages::ignition::TransceiverSelect;
 use gateway_messages::tlv;
 use gateway_messages::version;
+use gateway_messages::ComponentAction;
 use gateway_messages::ComponentDetails;
 use gateway_messages::DeviceCapabilities;
 use gateway_messages::DeviceDescriptionHeader;
@@ -801,6 +802,18 @@ impl SingleSp {
             .await
             .and_then(|(_addr, response, _data)| {
                 response.expect_switch_default_image_ack()
+            })
+    }
+
+    pub async fn component_action(
+        &self,
+        component: SpComponent,
+        action: ComponentAction,
+    ) -> Result<()> {
+        self.rpc(MgsRequest::ComponentAction { component, action })
+            .await
+            .and_then(|(_peer, response, _data)| {
+                response.expect_component_action_ack()
             })
     }
 }

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -87,6 +87,8 @@ pub(crate) trait SpResponseExt {
     fn expect_sys_reset_component_trigger_ack(self) -> Result<()>;
 
     fn expect_switch_default_image_ack(self) -> Result<()>;
+
+    fn expect_component_action_ack(self) -> Result<()>;
 }
 
 impl SpResponseExt for SpResponse {
@@ -547,6 +549,17 @@ impl SpResponseExt for SpResponse {
             Self::Error(err) => Err(CommunicationError::SpError(err)),
             other => Err(CommunicationError::BadResponseType {
                 expected: response_kind_names::SWITCH_DEFAULT_IMAGE_ACK,
+                got: other.name(),
+            }),
+        }
+    }
+
+    fn expect_component_action_ack(self) -> Result<()> {
+        match self {
+            Self::ComponentActionAck => Ok(()),
+            Self::Error(err) => Err(CommunicationError::SpError(err)),
+            other => Err(CommunicationError::BadResponseType {
+                expected: response_kind_names::COMPONENT_ACTION_ACK,
                 got: other.name(),
             }),
         }

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -170,6 +170,9 @@ impl SpResponseExt for SpResponse {
             Self::SwitchDefaultImageAck => {
                 response_kind_names::SWITCH_DEFAULT_IMAGE_ACK
             }
+            Self::ComponentActionAck => {
+                response_kind_names::COMPONENT_ACTION_ACK
+            }
         }
     }
 
@@ -602,4 +605,5 @@ mod response_kind_names {
         "reset_component_trigger_ack";
     pub(super) const SWITCH_DEFAULT_IMAGE_ACK: &str =
         "switch_default_image_ack";
+    pub(super) const COMPONENT_ACTION_ACK: &str = "component_action";
 }


### PR DESCRIPTION
This PR does a few things in service of https://github.com/oxidecomputer/facade/issues/45 and https://github.com/oxidecomputer/facade/issues/29

- Adds a new `ComponentAction` message, which is deliberately vague and extensible for future component-specific actions
- Adds `LedComponentAction`, which allows LED control
- Adds `SpComponent::SYSTEM_LED` and `DeviceCapabilities::IS_LED`
- Plumbs everything through `faux-mgs`

The system LED looks like this in MGS inventory:
```console
COMPONENT        STATUS       DEVICE           DESCRIPTION (CAPABILITIES)
sp               Present      sp               Service Processor (UPDATEABLE)
sp3-host-cpu     Present      sp3-host-cpu     Gimlet SP3 host cpu (HAS_SERIAL_CONSOLE)
host-boot-flash  Present      host-boot-flash  Gimlet host boot flash (UPDATEABLE)
system-led       Present      system-led       System attention LED (IS_LED)
```

It can be controlled through the new `system-led` subcommand:
```console
% cargo run --bin faux-mgs -- -ltrace --interface en0 system-led off
    Finished dev [unoptimized + debuginfo] target(s) in 0.07s
     Running `target/debug/faux-mgs -ltrace --interface en0 system-led off`
Apr 03 15:41:19.411 INFO creating SP handle on interface en0, component: faux-mgs
Apr 03 15:41:19.412 DEBG attempting initial SP discovery, discovery_addr: [ff02::1de:2]:11111, interface: en0, component: faux-mgs
Apr 03 15:41:19.412 TRCE sending request to SP, attempt: 1, request: Message { header: Header { version: 3, message_id: 1 }, kind: MgsRequest(Discover) }, interface: en0, component: faux-mgs
Apr 03 15:41:19.413 DEBG refreshed scope ID for SP interface, discovery_addr: [ff02::1de:2%15]:11111, interface: en0, interface: en0, component: faux-mgs
Apr 03 15:41:19.419 TRCE received response from SP, response: Discover(DiscoverResponse { sp_port: One }), header: Header { version: 3, message_id: 1 }, interface: en0, component: faux-mgs
Apr 03 15:41:19.419 INFO initial discovery complete, addr: [fe80::c1d:ddff:fef8:fb69%15]:11111, interface: en0, component: faux-mgs
Apr 03 15:41:19.419 TRCE sending request to SP, attempt: 1, request: Message { header: Header { version: 3, message_id: 2 }, kind: MgsRequest(ComponentAction { component: SpComponent { id: "system-led" }, action: Led(TurnOff) }) }, interface: en0, component: faux-mgs
Apr 03 15:41:19.423 TRCE received response from SP, response: ComponentActionAck, done
header: Header { version: 3, message_id: 2 }, interface: en0, component: faux-mgs

```

This should be merged before the associated Hubris PR, which does the SP side of implementation.

I'm **very open** to feedback on the API and architecture, which we should agree on before locking down!