### PR TITLE
Plumb switch default image

### DIFF
--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -883,9 +883,9 @@ async fn run_command(
             }
         }
         Command::Reset => {
-            sp.reset_prepare().await?;
+            sp.reset_component_prepare(SpComponent::SP_ITSELF).await?;
             info!(log, "SP is prepared to reset");
-            sp.reset_trigger().await?;
+            sp.reset_component_trigger(SpComponent::SP_ITSELF).await?;
             info!(log, "SP reset complete");
             Ok(vec!["reset complete".to_string()])
         }

--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -272,6 +272,12 @@ enum Command {
     /// Instruct the SP to reset.
     Reset,
 
+    /// Reset a component.
+    ///
+    /// This command is implemented for the component "rot" but may be
+    /// expanded to other components in the future.
+    ResetComponent { component: String },
+
     /// Set the boot image selection preference for a component.
     SwitchDefaultImage {
         component: String,
@@ -881,6 +887,20 @@ async fn run_command(
             info!(log, "SP is prepared to reset");
             sp.reset_trigger().await?;
             info!(log, "SP reset complete");
+            Ok(vec!["reset complete".to_string()])
+        }
+
+        Command::ResetComponent { component } => {
+            let sp_component = SpComponent::try_from(component.as_str())
+                .map_err(|_| anyhow!("invalid component name: {component}"))?;
+            sp.reset_component_prepare(sp_component).await?;
+            info!(
+                log,
+                "SP is repared to reset component {}",
+                component.as_str()
+            );
+            sp.reset_component_trigger(sp_component).await?;
+            info!(log, "SP reset component {} complete", component.as_str());
             Ok(vec!["reset complete".to_string()])
         }
 

--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -16,8 +16,10 @@ use futures::StreamExt;
 use gateway_messages::ignition::TransceiverSelect;
 use gateway_messages::IgnitionCommand;
 use gateway_messages::PowerState;
+use gateway_messages::SlotId;
 use gateway_messages::SpComponent;
 use gateway_messages::StartupOptions;
+use gateway_messages::SwitchDuration;
 use gateway_messages::UpdateId;
 use gateway_messages::UpdateStatus;
 use gateway_sp_comms::InMemoryHostPhase2Provider;
@@ -51,7 +53,7 @@ struct Args {
         long,
         default_value = "info",
         value_parser = level_from_str,
-        help = "Log level for MGS client",
+        help = "Log level for MGS client: {off,critical,error,warn,info,debug,trace}",
     )]
     log_level: Level,
 
@@ -269,6 +271,24 @@ enum Command {
 
     /// Instruct the SP to reset.
     Reset,
+
+    /// Set the boot image selection preference for a component.
+    SwitchDefaultImage {
+        component: String,
+
+        #[clap(
+            help = "Image slot identifier",
+            value_parser = slot_from_str,
+        )]
+        slot: SlotId,
+
+        #[clap(
+            help = "Duration 'Once' for image selection on the next reset only or 'Forever' for{n}\
+                  every reset and power-cycle.",
+            value_parser = duration_from_str,
+        )]
+        duration: SwitchDuration,
+    },
 }
 
 impl Command {
@@ -346,6 +366,22 @@ fn ignition_command_from_str(s: &str) -> Result<IgnitionCommand> {
         "power-off" => Ok(IgnitionCommand::PowerOff),
         "power-reset" => Ok(IgnitionCommand::PowerReset),
         _ => Err(anyhow!("Invalid ignition command: {s}")),
+    }
+}
+
+fn slot_from_str(s: &str) -> Result<SlotId> {
+    match s {
+        "A" | "a" | "0" => Ok(SlotId::A),
+        "B" | "b" | "1" => Ok(SlotId::B),
+        _ => Err(anyhow!("Invalid slot: {s}. Use A, a, 0, B, b, or 1.")),
+    }
+}
+
+fn duration_from_str(s: &str) -> Result<SwitchDuration> {
+    match s {
+        "once" => Ok(SwitchDuration::Once),
+        "forever" => Ok(SwitchDuration::Forever),
+        _ => Err(anyhow!("Invalid duration: {s}. Use 'once' or 'forever'.")),
     }
 }
 
@@ -846,6 +882,18 @@ async fn run_command(
             sp.reset_trigger().await?;
             info!(log, "SP reset complete");
             Ok(vec!["reset complete".to_string()])
+        }
+
+        Command::SwitchDefaultImage { component, slot, duration } => {
+            let sp_component = SpComponent::try_from(component.as_str())
+                .map_err(|_| anyhow!("invalid component name: {component}"))?;
+            sp.switch_default_image(sp_component, slot, duration).await?;
+            info!(
+                log,
+                "Switch default image for {} completed",
+                component.as_str()
+            );
+            Ok(vec!["switch_default_image".to_string()])
         }
         Command::SendHostNmi => {
             sp.send_host_nmi().await?;

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -123,6 +123,24 @@ pub enum BadRequestReason {
     DeserializationError,
 }
 
+/// Image slot name for SwitchDefaultImage
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
+)]
+pub enum SlotId {
+    A,
+    B,
+}
+
+/// Duration for SwitchDefaultImage
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
+)]
+pub enum SwitchDuration {
+    Once,
+    Forever,
+}
+
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
 )]

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -129,6 +129,16 @@ pub enum MgsRequest {
 
     SerialConsoleKeepAlive,
 
+    /// Reset a specific component
+    /// SP_ITSELF and ROT are supported
+    ResetComponentPrepare {
+        component: SpComponent,
+    },
+    ResetComponentTrigger {
+        component: SpComponent,
+    },
+
+    /// Change boot image selection on reset or power-on.
     SwitchDefaultImage {
         component: SpComponent,
         slot: SlotId,

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -7,7 +7,9 @@
 use crate::ignition::TransceiverSelect;
 use crate::BadRequestReason;
 use crate::PowerState;
+use crate::SlotId;
 use crate::SpComponent;
+use crate::SwitchDuration;
 use crate::UpdateId;
 use hubpack::SerializedSize;
 use serde::Deserialize;
@@ -126,6 +128,12 @@ pub enum MgsRequest {
     },
 
     SerialConsoleKeepAlive,
+
+    SwitchDefaultImage {
+        component: SpComponent,
+        slot: SlotId,
+        duration: SwitchDuration,
+    },
 }
 
 #[derive(

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -227,12 +227,6 @@ pub trait SpHandler {
         port: SpPort,
     ) -> Result<(), SpError>;
 
-    fn reset_prepare(
-        &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
-    ) -> Result<(), SpError>;
-
     /// Number of devices returned in the inventory of this SP.
     fn num_devices(&mut self, sender: SocketAddrV6, port: SpPort) -> u32;
 
@@ -1092,14 +1086,6 @@ mod tests {
         }
 
         fn serial_console_break(
-            &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
-        ) -> Result<(), SpError> {
-            unimplemented!()
-        }
-
-        fn reset_prepare(
             &mut self,
             _sender: SocketAddrV6,
             _port: SpPort,

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -25,6 +25,7 @@ use crate::MgsRequest;
 use crate::MgsResponse;
 use crate::PowerState;
 use crate::SerializedSize;
+use crate::SlotId;
 use crate::SpComponent;
 use crate::SpError;
 use crate::SpPort;
@@ -32,6 +33,7 @@ use crate::SpResponse;
 use crate::SpState;
 use crate::SpUpdatePrepare;
 use crate::StartupOptions;
+use crate::SwitchDuration;
 use crate::TlvPage;
 use crate::UpdateChunk;
 use crate::UpdateId;
@@ -358,6 +360,15 @@ pub trait SpHandler {
         &mut self,
         key: [u8; 4],
     ) -> Result<&'static [u8], SpError>;
+
+    fn switch_default_image(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        component: SpComponent,
+        slot: SlotId,
+        duration: SwitchDuration,
+    ) -> Result<(), SpError>;
 }
 
 /// Handle a single incoming message.
@@ -853,6 +864,9 @@ fn handle_mgs_request<H: SpHandler>(
                 }
             })
         }
+        MgsRequest::SwitchDefaultImage { component, slot, duration } => handler
+            .switch_default_image(sender, port, component, slot, duration)
+            .map(|()| SpResponse::SwitchDefaultImageAck),
     };
 
     let response = match result {
@@ -1202,6 +1216,17 @@ mod tests {
             &mut self,
             _key: [u8; 4],
         ) -> Result<&'static [u8], SpError> {
+            unimplemented!()
+        }
+
+        fn switch_default_image(
+            &mut self,
+            _sender: SocketAddrV6,
+            _port: SpPort,
+            _component: SpComponent,
+            _slot: SlotId,
+            _duration: SwitchDuration,
+        ) -> Result<(), SpError> {
             unimplemented!()
         }
     }

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -38,7 +38,6 @@ use crate::TlvPage;
 use crate::UpdateChunk;
 use crate::UpdateId;
 use crate::UpdateStatus;
-use core::convert::Infallible;
 use hubpack::error::Error as HubpackError;
 use hubpack::error::Result as HubpackResult;
 
@@ -233,13 +232,6 @@ pub trait SpHandler {
         sender: SocketAddrV6,
         port: SpPort,
     ) -> Result<(), SpError>;
-
-    // On success, this method cannot return (it should perform a reset).
-    fn reset_trigger(
-        &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
-    ) -> Result<Infallible, SpError>;
 
     /// Number of devices returned in the inventory of this SP.
     fn num_devices(&mut self, sender: SocketAddrV6, port: SpPort) -> u32;
@@ -683,8 +675,7 @@ fn handle_mgs_request<H: SpHandler>(
     let trailing_data = match &kind {
         MgsRequest::UpdateChunk(_)
         | MgsRequest::SerialConsoleWrite { .. }
-        | MgsRequest::SetIpccKeyLookupValue { .. }
-        | MgsRequest::ResetComponentTrigger { .. } => leftover,
+        | MgsRequest::SetIpccKeyLookupValue { .. } => leftover,
         _ => {
             if !leftover.is_empty() {
                 return (
@@ -796,18 +787,11 @@ fn handle_mgs_request<H: SpHandler>(
             .set_power_state(sender, port, power_state)
             .map(|()| SpResponse::SetPowerStateAck),
         MgsRequest::ResetPrepare => handler
-            .reset_prepare(sender, port)
+            .reset_component_prepare(sender, port, SpComponent::SP_ITSELF)
             .map(|()| SpResponse::ResetPrepareAck),
-        MgsRequest::ResetTrigger => {
-            handler.reset_trigger(sender, port).map(|infallible| {
-                // A bit of type system magic here; `reset_trigger`'s
-                // success type (`Infallible`) cannot be instantiated. We can
-                // provide an empty match to teach the type system that an
-                // `Infallible` (which can't exist) can be converted to a
-                // `SpResponse` (or any other type!).
-                match infallible {}
-            })
-        }
+        MgsRequest::ResetTrigger => handler
+            .reset_component_trigger(sender, port, SpComponent::SP_ITSELF)
+            .map(|()| SpResponse::ResetComponentTriggerAck),
         MgsRequest::Inventory { device_index } => {
             let total_devices = handler.num_devices(sender, port);
             // If a caller asks for an index past our end, clamp it.
@@ -1120,14 +1104,6 @@ mod tests {
             _sender: SocketAddrV6,
             _port: SpPort,
         ) -> Result<(), SpError> {
-            unimplemented!()
-        }
-
-        fn reset_trigger(
-            &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
-        ) -> Result<Infallible, SpError> {
             unimplemented!()
         }
 

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -106,6 +106,7 @@ pub enum SpResponse {
     CabooseValue,
 
     SerialConsoleKeepAliveAck,
+    SwitchDefaultImageAck,
 }
 
 /// Identifier for one of of an SP's KSZ8463 management-network-facing ports.
@@ -471,6 +472,10 @@ pub enum SpError {
     ImageBoardUnknown,
     /// The new image has a `BORD` key that does not match the current image
     ImageBoardMismatch,
+    /// There will be policy violations for some requests:
+    ///   - No image in SlotId (what suitability checks are needed?)
+    ///   - Lower epoch than current in SlotId
+    SwitchDefaultImageError(u32),
 }
 
 impl fmt::Display for SpError {
@@ -569,6 +574,9 @@ impl fmt::Display for SpError {
             }
             Self::ImageBoardMismatch => {
                 write!(f, "the image has a board that doesn't match the current image")
+            }
+            Self::SwitchDefaultImageError(code) => {
+                write!(f, "switch default image failed with code {code}")
             }
         }
     }

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -106,6 +106,8 @@ pub enum SpResponse {
     CabooseValue,
 
     SerialConsoleKeepAliveAck,
+    ResetComponentPrepareAck,
+    ResetComponentTriggerAck,
     SwitchDefaultImageAck,
 }
 
@@ -472,6 +474,11 @@ pub enum SpError {
     ImageBoardUnknown,
     /// The new image has a `BORD` key that does not match the current image
     ImageBoardMismatch,
+    /// Received a `ResetComponentTrigger` request without first receiving a
+    /// `ResetComponentPrepare` request. This can be used to detect a successful
+    /// reset on the SP_ITSELF. Not used for the ROT where the SP observes
+    /// the RoT reset and can report success.
+    ResetComponentTriggerWithoutPrepare,
     /// There will be policy violations for some requests:
     ///   - No image in SlotId (what suitability checks are needed?)
     ///   - Lower epoch than current in SlotId
@@ -574,6 +581,9 @@ impl fmt::Display for SpError {
             }
             Self::ImageBoardMismatch => {
                 write!(f, "the image has a board that doesn't match the current image")
+            }
+            Self::ResetComponentTriggerWithoutPrepare => {
+                write!(f, "reset component trigger requested without a preceding reset component prepare")
             }
             Self::SwitchDefaultImageError(code) => {
                 write!(f, "switch default image failed with code {code}")

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -780,21 +780,13 @@ impl SingleSp {
         &self,
         component: SpComponent,
     ) -> Result<()> {
-        debug!(
-            self.log,
-            "sending ResetComponentPrepare component:{component:?}"
-        );
-        let r = self
-            .rpc(MgsRequest::ResetComponentPrepare { component })
+        self.rpc(MgsRequest::ResetComponentPrepare { component })
             .await
             .and_then(|(_peer, response, _data)| {
                 response
                     .expect_sys_reset_component_prepare_ack()
                     .map_err(Into::into)
-            });
-        debug!(self.log, "response from ResetComponentPrepare component:{component:?} is {r:?}");
-
-        r
+            })
     }
 
     /// Instruct the SP to reset a component.
@@ -834,15 +826,11 @@ impl SingleSp {
         slot: SlotId,
         duration: SwitchDuration,
     ) -> Result<()> {
-        let response = self
-            .rpc(MgsRequest::SwitchDefaultImage { component, slot, duration })
-            .await;
-        match response {
-            Ok((_addr, response, _data)) => {
+        self.rpc(MgsRequest::SwitchDefaultImage { component, slot, duration })
+            .await
+            .and_then(|(_addr, response, _data)| {
                 response.expect_switch_default_image_ack()
-            }
-            Err(other) => Err(other),
-        }
+            })
     }
 }
 

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -31,6 +31,7 @@ use gateway_messages::Message;
 use gateway_messages::MessageKind;
 use gateway_messages::MgsRequest;
 use gateway_messages::PowerState;
+use gateway_messages::SlotId;
 use gateway_messages::SpComponent;
 use gateway_messages::SpError;
 use gateway_messages::SpPort;
@@ -38,6 +39,7 @@ use gateway_messages::SpRequest;
 use gateway_messages::SpResponse;
 use gateway_messages::SpState;
 use gateway_messages::StartupOptions;
+use gateway_messages::SwitchDuration;
 use gateway_messages::TlvPage;
 use gateway_messages::UpdateStatus;
 use gateway_messages::MIN_TRAILING_DATA_LEN;
@@ -761,6 +763,26 @@ impl SingleSp {
             response.expect_caboose_value().unwrap();
             data
         })
+    }
+
+    /// Instruct the SP to reset a component.
+    ///
+    /// Only valid after a successful call to `reset_component_prepare()`.
+    pub async fn switch_default_image(
+        &self,
+        component: SpComponent,
+        slot: SlotId,
+        duration: SwitchDuration,
+    ) -> Result<()> {
+        let response = self
+            .rpc(MgsRequest::SwitchDefaultImage { component, slot, duration })
+            .await;
+        match response {
+            Ok((_addr, response, _data)) => {
+                response.expect_switch_default_image_ack()
+            }
+            Err(other) => Err(other),
+        }
     }
 }
 

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -84,6 +84,10 @@ pub(crate) trait SpResponseExt {
 
     fn expect_caboose_value(self) -> Result<()>;
 
+    fn expect_sys_reset_component_prepare_ack(self) -> Result<()>;
+
+    fn expect_sys_reset_component_trigger_ack(self) -> Result<()>;
+
     fn expect_switch_default_image_ack(self) -> Result<()>;
 }
 
@@ -159,6 +163,12 @@ impl SpResponseExt for SpResponse {
                 response_kind_names::SET_IPCC_KEY_LOOKUP_VALUE_ACK
             }
             Self::CabooseValue => response_kind_names::CABOOSE_VALUE,
+            Self::ResetComponentPrepareAck => {
+                response_kind_names::RESET_COMPONENT_PREPARE_ACK
+            }
+            Self::ResetComponentTriggerAck => {
+                response_kind_names::RESET_COMPONENT_TRIGGER_ACK
+            }
             Self::SwitchDefaultImageAck => {
                 response_kind_names::SWITCH_DEFAULT_IMAGE_ACK
             }
@@ -519,6 +529,28 @@ impl SpResponseExt for SpResponse {
         }
     }
 
+    fn expect_sys_reset_component_prepare_ack(self) -> Result<()> {
+        match self {
+            Self::ResetComponentPrepareAck => Ok(()),
+            Self::Error(err) => Err(CommunicationError::SpError(err)),
+            other => Err(CommunicationError::BadResponseType {
+                expected: response_kind_names::RESET_COMPONENT_PREPARE_ACK,
+                got: other.name(),
+            }),
+        }
+    }
+
+    fn expect_sys_reset_component_trigger_ack(self) -> Result<()> {
+        match self {
+            Self::ResetComponentTriggerAck => Ok(()),
+            Self::Error(err) => Err(CommunicationError::SpError(err)),
+            other => Err(CommunicationError::BadResponseType {
+                expected: response_kind_names::RESET_COMPONENT_TRIGGER_ACK,
+                got: other.name(),
+            }),
+        }
+    }
+
     fn expect_switch_default_image_ack(self) -> Result<()> {
         match self {
             Self::SwitchDefaultImageAck => Ok(()),
@@ -577,6 +609,10 @@ mod response_kind_names {
     pub(super) const SET_IPCC_KEY_LOOKUP_VALUE_ACK: &str =
         "set_ipcc_key_lookup_value_ack";
     pub(super) const CABOOSE_VALUE: &str = "caboose_value";
+    pub(super) const RESET_COMPONENT_PREPARE_ACK: &str =
+        "reset_component_prepare_ack";
+    pub(super) const RESET_COMPONENT_TRIGGER_ACK: &str =
+        "reset_component_trigger_ack";
     pub(super) const SWITCH_DEFAULT_IMAGE_ACK: &str =
         "switch_default_image_ack";
 }

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -83,6 +83,8 @@ pub(crate) trait SpResponseExt {
     fn expect_set_ipcc_key_lookup_value_ack(self) -> Result<()>;
 
     fn expect_caboose_value(self) -> Result<()>;
+
+    fn expect_switch_default_image_ack(self) -> Result<()>;
 }
 
 impl SpResponseExt for SpResponse {
@@ -157,6 +159,9 @@ impl SpResponseExt for SpResponse {
                 response_kind_names::SET_IPCC_KEY_LOOKUP_VALUE_ACK
             }
             Self::CabooseValue => response_kind_names::CABOOSE_VALUE,
+            Self::SwitchDefaultImageAck => {
+                response_kind_names::SWITCH_DEFAULT_IMAGE_ACK
+            }
         }
     }
 
@@ -513,6 +518,17 @@ impl SpResponseExt for SpResponse {
             }),
         }
     }
+
+    fn expect_switch_default_image_ack(self) -> Result<()> {
+        match self {
+            Self::SwitchDefaultImageAck => Ok(()),
+            Self::Error(err) => Err(CommunicationError::SpError(err)),
+            other => Err(CommunicationError::BadResponseType {
+                expected: response_kind_names::SWITCH_DEFAULT_IMAGE_ACK,
+                got: other.name(),
+            }),
+        }
+    }
 }
 
 mod response_kind_names {
@@ -561,4 +577,6 @@ mod response_kind_names {
     pub(super) const SET_IPCC_KEY_LOOKUP_VALUE_ACK: &str =
         "set_ipcc_key_lookup_value_ack";
     pub(super) const CABOOSE_VALUE: &str = "caboose_value";
+    pub(super) const SWITCH_DEFAULT_IMAGE_ACK: &str =
+        "switch_default_image_ack";
 }

--- a/gateway-sp-comms/src/sp_response_ext.rs
+++ b/gateway-sp-comms/src/sp_response_ext.rs
@@ -60,8 +60,6 @@ pub(crate) trait SpResponseExt {
 
     fn expect_set_power_state_ack(self) -> Result<()>;
 
-    fn expect_sys_reset_prepare_ack(self) -> Result<()>;
-
     fn expect_inventory(self) -> Result<TlvPage>;
 
     fn expect_startup_options(self) -> Result<StartupOptions>;
@@ -392,17 +390,6 @@ impl SpResponseExt for SpResponse {
             Self::Error(err) => Err(CommunicationError::SpError(err)),
             other => Err(CommunicationError::BadResponseType {
                 expected: response_kind_names::SET_POWER_STATE_ACK,
-                got: other.name(),
-            }),
-        }
-    }
-
-    fn expect_sys_reset_prepare_ack(self) -> Result<()> {
-        match self {
-            Self::ResetPrepareAck => Ok(()),
-            Self::Error(err) => Err(CommunicationError::SpError(err)),
-            other => Err(CommunicationError::BadResponseType {
-                expected: response_kind_names::RESET_PREPARE_ACK,
                 got: other.name(),
             }),
         }


### PR DESCRIPTION
This is the MGS side of the code required for RoT boot selection as well resetting the RoT. A corresponding hubris PR will be out later today.

This is all @lzrd's code and it looks great to me. I have no proposed changes. I tested it out using corresponding hubris code and verified by reading the right CFPA registers via `humility readmem`. The boot versions change as expected.

I'm opening the PR just to move this forward and get @jgallagher's review since MGS is largely his baby. 