### PR TITLE
Format update UUID

### DIFF
--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -862,7 +862,7 @@ async fn run_command(
             sp.update_abort(sp_component, update_id).await.with_context(
                 || format!("aborting update to {} failed", component),
             )?;
-            Ok(vec!["update {update_id} aborted".to_string()])
+            Ok(vec![format!("update {update_id} aborted")])
         }
         Command::PowerState { new_power_state } => {
             if let Some(state) = new_power_state {


### PR DESCRIPTION
Tiny fix I noticed when resolving the issue that lead to https://github.com/oxidecomputer/hubris/pull/1263. We called `.to_string()` rather than `format!()` leading to log messages containing things like `update {update_id} aborted` instead of a formatted string.