### PR TITLE
Bump hubpack and fix `serde`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ hex = "0.4.3"
 hubpack = "0.1.2"
 lru-cache = "0.1.2"
 once_cell = "1.15.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-big-array = "0.5.0"
 serde_json = "1.0.95"
 serde_repr = { version = "0.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,6 @@ default-members = [
 resolver = "2"
 
 [workspace.dependencies]
-# TODO point back to crates.io after a new release
-hubpack = { git = "https://github.com/cbiffle/hubpack" }
-
 # TODO: Replace with real nix after https://github.com/nix-rust/nix/pull/1973 is
 # published to crates.io
 nix = { git = "https://github.com/jgallagher/nix", branch = "r0.26-illumos" }
@@ -31,6 +28,7 @@ futures = "0.3.24"
 fxhash = "0.2.1"
 glob = "0.3.1"
 hex = "0.4.3"
+hubpack = "0.1.2"
 lru-cache = "0.1.2"
 once_cell = "1.15.0"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
`hubpack v0.1.2` is released, so let's use it!

`serde` needs `default-features = false`; otherwise, feature unification will enable default features (including `std`) in the Hubris build!