### PR TITLE
Add data sent to host phase2 progress

### DIFF
--- a/gateway-sp-comms/Cargo.toml
+++ b/gateway-sp-comms/Cargo.toml
@@ -26,7 +26,7 @@ usdt.workspace = true
 uuid.workspace = true
 zip.workspace = true
 
-gateway-messages.workspace = true
+gateway-messages = { workspace = true, features = ["std"] }
 
 # This is required for the build.rs script to check for an appropriate compiler
 # version so that `usdt` can be built on stable rust.

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -763,17 +763,18 @@ impl SingleSp {
         // retry until we get back an error indicating the
         // SP wasn't expecting a reset trigger (because it has reset!).
         // If we are resetting the RoT, the SP will send an ack.
-        // When resetting the RoT, the SP SpRot client will either
-        // timeout on a response because the RoT was reset or because the message
-        // got dropped. TODO: have this code and/or SP check a boot nonce or other
+        // When resetting the RoT, the SP SpRot client will either timeout on a
+        // response because the RoT was reset or because the message got
+        // dropped. TODO: have this code and/or SP check a boot nonce or other
         // information to verify that the RoT did reset.
         let response =
             self.rpc(MgsRequest::ResetComponentTrigger { component }).await;
         match response {
             Ok((_addr, response, _data)) => {
                 if component == SpComponent::SP_ITSELF {
-                    // Reset trigger should retry until we get back an error indicating the
-                    // SP wasn't expecting a reset trigger (because it has reset!).
+                    // Reset trigger should retry until we get back an error
+                    // indicating the SP wasn't expecting a reset trigger
+                    // (because it has reset!).
                     Err(CommunicationError::BadResponseType {
                         expected: "system-reset",
                         got: response.name(),

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -98,6 +98,7 @@ type Result<T, E = CommunicationError> = std::result::Result<T, E>;
 pub struct HostPhase2Request {
     pub hash: [u8; 32],
     pub offset: u64,
+    pub data_sent: u64,
     pub received: Instant,
 }
 


### PR DESCRIPTION
This required some refactoring to send the progress reports _after_
we've requested data from the host phase2 provider and sent data to the
SP, which probably makes them more accurate anyway! Previously we would
update our progress even if the request from the SP was nonsense or we
failed to reply to it; now we only update progress after we know we've
successfully sent data to an SP (although of course we don't know for
sure that it received it).

The primary motivator for this is correctness in wicket: prior to this PR, progress
for delivery of the trampoline image looks like it stalls at 99.9%, because we
were reporting the _start_ of the last data request from the SP, but we really
want to report the _end_. That requires the changes in this PR: we need to know
how much data we sent in response to the SP's request.