### PR TITLE
RoT updates: take hubris archive instead of final.bin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,7 +699,7 @@ dependencies = [
 [[package]]
 name = "hubtools"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/hubtools.git#8f822e40dd97e1cd1732f76da4422e4a61866004"
+source = "git+https://github.com/oxidecomputer/hubtools.git#e3e938dc5493c30f4c830d2ee2b5d75d51b7775d"
 dependencies = [
  "lpc55_areas",
  "lpc55_sign",

--- a/gateway-sp-comms/src/error.rs
+++ b/gateway-sp-comms/src/error.rs
@@ -85,16 +85,18 @@ pub enum UpdateError {
     ImageEmpty,
     #[error("update image is too large")]
     ImageTooLarge,
-    #[error("hubris archive error: {0}")]
+    #[error("hubris archive error")]
     HubtoolsError(#[from] hubtools::Error),
-    #[error("error reading caboose in hubris archive: {0}")]
+    #[error("error reading caboose in hubris archive")]
     CabooseError(#[from] hubtools::CabooseError),
     #[error("board mismatch: SP is {sp} but archive is for {archive}")]
     BoardMismatch { sp: String, archive: String },
+    #[error("RoT slot mismatch: target slot {slot} cannot be written with {image_name:?} image")]
+    RotSlotMismatch { slot: u16, image_name: String },
     #[error("error reading aux flash image: {0:?}")]
     TlvcError(tlvc::TlvcReadError),
     #[error("corrupt aux flash image: {0}")]
     CorruptTlvc(String),
-    #[error("failed to send update message to SP: {0}")]
+    #[error("failed to send update message to SP")]
     Communication(#[from] CommunicationError),
 }

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -70,6 +70,7 @@ use uuid::Uuid;
 mod update;
 
 use self::update::start_component_update;
+use self::update::start_rot_update;
 use self::update::start_sp_update;
 use self::update::update_status;
 
@@ -587,6 +588,9 @@ impl SingleSp {
                 ));
             }
             start_sp_update(&self.cmds_tx, update_id, image, self.log()).await
+        } else if component == SpComponent::ROT {
+            start_rot_update(&self.cmds_tx, update_id, slot, image, self.log())
+                .await
         } else {
             start_component_update(
                 &self.cmds_tx,


### PR DESCRIPTION
Updated instructions for RoT updates over the network by hand (also requires a recent SP image); I'll be adding analogous steps to `wicketd` real soon now:

1. Determine which slot is currently running.

```
john@jeeves ~ $ ./faux-mgs --interface madrid_tp0 --discovery-addr '[fe80::aa40:25ff:fe04:147]:11111' component-active-slot rot
...
May 03 20:45:42.354 INFO active slot for "rot": 0
```

2. Send an update to the not-currently-active slot, using the correct a/b hubris archive:

```
john@jeeves ~ $ ./faux-mgs --interface madrid_tp0 --discovery-addr '[fe80::aa40:25ff:fe04:147]:11111' update rot 1 build-gimlet-rot-c-image-b.zip
...
update complete
```

If you mismatch the slot number and a/b archive, you will get an error from faux-mgs before it ever tries to send the update to the SP/RoT:

```
john@jeeves ~ $ ./faux-mgs --interface madrid_tp0 --discovery-addr '[fe80::aa40:25ff:fe04:147]:11111' update rot 1 build-gimlet-rot-c-image-a.zip
Error: updating rot slot 1 to build-gimlet-rot-c-image-a.zip failed: failed to start update: RoT slot mismatch: target slot 1 cannot be written with "a" image
```

3. Set the active slot to the slot you just updated

```
john@jeeves ~ $ ./faux-mgs --interface madrid_tp0 --discovery-addr '[fe80::aa40:25ff:fe04:147]:11111' component-active-slot rot --set 1 --persist
...
set active slot for "rot" to 1
```

4. Reset the RoT:

```
john@jeeves ~ $ ./faux-mgs --interface madrid_tp0 --discovery-addr '[fe80::aa40:25ff:fe04:147]:11111' reset-component rot
```