### PR TITLE
Add support for reading an individual component's caboose

### DIFF
--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -1109,8 +1109,8 @@ async fn run_command(
         }
         Command::ReadComponentCaboose { component, slot, key } => {
             let slot = match (component, slot.as_deref()) {
-                (SpComponent::SP_ITSELF, Some("active") | None) => 0,
-                (SpComponent::SP_ITSELF, Some("inactive")) => 1,
+                (SpComponent::SP_ITSELF, Some("active" | "0") | None) => 0,
+                (SpComponent::SP_ITSELF, Some("inactive" | "1")) => 1,
                 (SpComponent::SP_ITSELF, v) => {
                     bail!(
                         "invalid slot '{}' for SP; \
@@ -1118,8 +1118,8 @@ async fn run_command(
                         v.unwrap(),
                     )
                 }
-                (SpComponent::ROT, Some("A" | "a")) => 0,
-                (SpComponent::ROT, Some("B" | "b")) => 1,
+                (SpComponent::ROT, Some("A" | "a" | "0")) => 0,
+                (SpComponent::ROT, Some("B" | "b" | "1")) => 1,
                 (SpComponent::ROT, None) => {
                     bail!("must provide slot ('A' or 'B') for RoT")
                 }

--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -375,7 +375,7 @@ fn parse_tlvc_key(key: &str) -> Result<[u8; 4]> {
 
 fn parse_sp_component(component: &str) -> Result<SpComponent> {
     SpComponent::try_from(component)
-        .map_err(|_| anyhow!("invalid component name: {}", component))
+        .map_err(|_| anyhow!("invalid component name: {component}"))
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -63,7 +63,7 @@ pub const MAX_SERIALIZED_SIZE: usize = 1024;
 /// for more detail and discussion.
 pub mod version {
     pub const MIN: u32 = 2;
-    pub const CURRENT: u32 = 4;
+    pub const CURRENT: u32 = 5;
 }
 
 #[derive(

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -390,6 +390,17 @@ pub enum CabooseValue {
     Rot { slot: u16, pos: core::ops::Range<u32> },
 }
 
+impl CabooseValue {
+    fn len(&self) -> usize {
+        match self {
+            CabooseValue::Local(s) => s.len(),
+            CabooseValue::Rot { pos, .. } | CabooseValue::Bank2 { pos, .. } => {
+                (pos.end - pos.start) as usize
+            }
+        }
+    }
+}
+
 /// Minimum guaranteed space for trailing data in a single packet.
 ///
 /// Depending on the [`Message`] payload, there may be more space for trailing

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -364,7 +364,13 @@ impl TryFrom<&str> for SpComponent {
 /// the output.
 #[derive(Clone)]
 pub enum CabooseValue {
+    /// Local flash bank on the SP
     Local(&'static [u8]),
+
+    /// Alternate flash bank on the SP
+    Bank2 { pos: core::ops::Range<u32> },
+
+    /// Root of trust
     Rot { slot: u16, pos: core::ops::Range<u32> },
 }
 

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -378,9 +378,15 @@ pub enum CabooseValue {
     Local(&'static [u8]),
 
     /// Alternate flash bank on the SP
+    ///
+    /// The value's position is given relative to the caboose, i.e. 0 is the
+    /// first byte of the caboose.
     Bank2 { pos: core::ops::Range<u32> },
 
     /// Root of trust
+    ///
+    /// The value's position is given relative to the caboose, i.e. 0 is the
+    /// first byte of the caboose.
     Rot { slot: u16, pos: core::ops::Range<u32> },
 }
 

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -237,8 +237,8 @@ impl<'de> Deserialize<'de> for SpComponent {
     }
 }
 
-impl std::fmt::Display for SpComponent {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for SpComponent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if let Some(s) = self.as_str() {
             write!(f, "{s}")
         } else {

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -354,6 +354,20 @@ impl TryFrom<&str> for SpComponent {
     }
 }
 
+/// A value found in the caboose
+///
+/// If we are reading from the local caboose, this is a simple slice into
+/// static memory (which the task is allowed to access).
+///
+/// However, if we were reading from the caboose of the RoT, we instead store
+/// the location of the value, so that we can read it again when packing it into
+/// the output.
+#[derive(Clone)]
+pub enum CabooseValue {
+    Local(&'static [u8]),
+    Rot { slot: u16, pos: core::ops::Range<u32> },
+}
+
 /// Minimum guaranteed space for trailing data in a single packet.
 ///
 /// Depending on the [`Message`] payload, there may be more space for trailing

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -237,6 +237,16 @@ impl<'de> Deserialize<'de> for SpComponent {
     }
 }
 
+impl std::fmt::Display for SpComponent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(s) = self.as_str() {
+            write!(f, "{s}")
+        } else {
+            write!(f, "{self:?}")
+        }
+    }
+}
+
 impl SpComponent {
     /// Maximum number of bytes for a component ID.
     pub const MAX_ID_LENGTH: usize = 16;

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -364,43 +364,6 @@ impl TryFrom<&str> for SpComponent {
     }
 }
 
-/// A value found in the caboose
-///
-/// If we are reading from the local caboose, this is a simple slice into
-/// static memory (which the task is allowed to access).
-///
-/// However, if we were reading from the caboose of the RoT, we instead store
-/// the location of the value, so that we can read it again when packing it into
-/// the output.
-#[derive(Clone)]
-pub enum CabooseValue {
-    /// Local flash bank on the SP
-    Local(&'static [u8]),
-
-    /// Alternate flash bank on the SP
-    ///
-    /// The value's position is given relative to the caboose, i.e. 0 is the
-    /// first byte of the caboose.
-    Bank2 { pos: core::ops::Range<u32> },
-
-    /// Root of trust
-    ///
-    /// The value's position is given relative to the caboose, i.e. 0 is the
-    /// first byte of the caboose.
-    Rot { slot: u16, pos: core::ops::Range<u32> },
-}
-
-impl CabooseValue {
-    fn len(&self) -> usize {
-        match self {
-            CabooseValue::Local(s) => s.len(),
-            CabooseValue::Rot { pos, .. } | CabooseValue::Bank2 { pos, .. } => {
-                (pos.end - pos.start) as usize
-            }
-        }
-    }
-}
-
 /// Minimum guaranteed space for trailing data in a single packet.
 ///
 /// Depending on the [`Message`] payload, there may be more space for trailing

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -155,6 +155,7 @@ pub enum MgsRequest {
     /// The resulting value is serialized in the trailer of the packet
     ReadComponentCaboose {
         component: SpComponent,
+        slot: u16,
         key: [u8; 4],
     },
 }

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -149,6 +149,14 @@ pub enum MgsRequest {
         component: SpComponent,
         action: ComponentAction,
     },
+
+    /// Reads a value from the caboose of the selected component
+    ///
+    /// The resulting value is serialized in the trailer of the packet
+    ReadComponentCaboose {
+        component: SpComponent,
+        key: [u8; 4],
+    },
 }
 
 #[derive(

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -9,6 +9,7 @@ use crate::ignition::LinkEvents;
 use crate::tlv;
 use crate::version;
 use crate::BadRequestReason;
+use crate::CabooseValue;
 use crate::ComponentAction;
 use crate::ComponentDetails;
 use crate::ComponentUpdatePrepare;
@@ -945,20 +946,6 @@ fn handle_mgs_request<H: SpHandler>(
     };
 
     (response, outgoing_trailing_data)
-}
-
-/// A value found in the caboose
-///
-/// If we were reading from the local caboose, this is a simple slice into
-/// static memory (which the task is allowed to access).
-///
-/// However, if we were reading from the _remote_ caboose, we instead store the
-/// location of the value, so that we can read it again when packing it into the
-/// output.
-#[derive(Clone)]
-pub enum CabooseValue {
-    Local(&'static [u8]),
-    Rot { slot: u16, pos: core::ops::Range<u32> },
 }
 
 impl CabooseValue {

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -948,17 +948,6 @@ fn handle_mgs_request<H: SpHandler>(
     (response, outgoing_trailing_data)
 }
 
-impl CabooseValue {
-    fn len(&self) -> usize {
-        match self {
-            CabooseValue::Local(s) => s.len(),
-            CabooseValue::Rot { pos, .. } | CabooseValue::Bank2 { pos, .. } => {
-                (pos.end - pos.start) as usize
-            }
-        }
-    }
-}
-
 enum OutgoingTrailingData<H: SpHandler> {
     DeviceInventory { device_index: u32, total_devices: u32 },
     ComponentDetails { component: SpComponent, offset: u32, total: u32 },

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -952,7 +952,9 @@ impl CabooseValue {
     fn len(&self) -> usize {
         match self {
             CabooseValue::Local(s) => s.len(),
-            CabooseValue::Rot { pos, .. } => (pos.end - pos.start) as usize,
+            CabooseValue::Rot { pos, .. } | CabooseValue::Bank2 { pos, .. } => {
+                (pos.end - pos.start) as usize
+            }
         }
     }
 }

--- a/gateway-messages/tests/versioning/mod.rs
+++ b/gateway-messages/tests/versioning/mod.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 mod v2;
 mod v3;
 mod v4;
+mod v5;
 
 pub fn assert_serialized(
     out: &mut [u8],

--- a/gateway-messages/tests/versioning/v5.rs
+++ b/gateway-messages/tests/versioning/v5.rs
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! The tests in this module check that the serialized form of messages from MGS
+//! protocol version 5 have not changed.
+//!
+//! If a test in this module fails, _do not change the test_! This means you
+//! have changed, deleted, or reordered an existing message type or enum
+//! variant, and you should revert that change. This will remain true until we
+//! bump the `version::MIN` to a value higher than 4, at which point these tests
+//! can be removed as we will stop supporting v5.
+
+use super::assert_serialized;
+use gateway_messages::MgsRequest;
+use gateway_messages::SerializedSize;
+use gateway_messages::SpComponent;
+
+#[test]
+fn mgs_request() {
+    let mut out = [0; MgsRequest::MAX_SIZE];
+
+    let request = MgsRequest::ReadComponentCaboose {
+        component: SpComponent::SP_ITSELF,
+        key: [1, 2, 3, 4],
+    };
+    let expected = &[
+        37, // ReadComponentCaboose
+        b's', b'p', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // SP_ITSELF
+        1, 2, 3, 4,
+    ];
+    assert_serialized(&mut out, expected, &request);
+}

--- a/gateway-messages/tests/versioning/v5.rs
+++ b/gateway-messages/tests/versioning/v5.rs
@@ -22,11 +22,13 @@ fn mgs_request() {
 
     let request = MgsRequest::ReadComponentCaboose {
         component: SpComponent::SP_ITSELF,
+        slot: 1,
         key: [1, 2, 3, 4],
     };
     let expected = &[
         37, // ReadComponentCaboose
         b's', b'p', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // SP_ITSELF
+        1, 0, // slot
         1, 2, 3, 4,
     ];
     assert_serialized(&mut out, expected, &request);

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -811,6 +811,25 @@ impl SingleSp {
                 response.expect_component_action_ack()
             })
     }
+
+    pub async fn read_component_caboose(
+        &self,
+        component: SpComponent,
+        slot: u16,
+        key: [u8; 4],
+    ) -> Result<Vec<u8>> {
+        let result = rpc(
+            &self.cmds_tx,
+            MgsRequest::ReadComponentCaboose { component, slot, key },
+            None,
+        )
+        .await;
+
+        result.result.map(|(_peer, response, data)| {
+            response.expect_caboose_value().unwrap();
+            data
+        })
+    }
 }
 
 // Helper trait to call a "paginated" (i.e., split across multiple UDP packets)

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -728,6 +728,11 @@ impl SingleSp {
         })
     }
 
+    /// Reads a single value from the SP's caboose (in the active slot)
+    ///
+    /// This can eventually be deprecated in favor of
+    /// `read_component_caboose(SpComponent::SP_ITSELF, 0, key)`, once that
+    /// message is widely accepted by SPs in the field.
     pub async fn get_caboose_value(&self, key: [u8; 4]) -> Result<Vec<u8>> {
         let result =
             rpc(&self.cmds_tx, MgsRequest::ReadCaboose { key }, None).await;

--- a/gateway-sp-comms/src/single_sp/update.rs
+++ b/gateway-sp-comms/src/single_sp/update.rs
@@ -68,6 +68,9 @@ pub(super) async fn start_sp_update(
     // can avoid an unnecessary erase/write cycle.
     let caboose = archive.read_caboose()?;
     let archive_board = caboose.board()?;
+
+    // In the future, we could use `ReadComponentCaboose` here instead, but
+    // `ReadCaboose` is older (and thus more widely compatible with SP images).
     let sp_board =
         super::rpc(cmds_tx, MgsRequest::ReadCaboose { key: *b"BORD" }, None)
             .await


### PR DESCRIPTION
There's a bunch of plumbing here and a corresponding Hubris PR that I will open shortly.

Briefly, this adds the `ReadComponentCaboose` message, which requests a component + slot + key (effectively deprecating the older `ReadCaboose` message).

The `CabooseValue` – used to serialize trailing data after the packet message – is split into three flavors:
- A local slice (`&'static [u8]`)
- A value in the caboose on the other SP flash bank
- A value in the RoT's caboose

There's a bunch of new code to handle this in `sp_impl.rs`; it's particularly gnarly because reading the caboose could fail (e.g. if the RoT refuses to answer us).

As a drive-by fix, I also made `SpComponent` deserialize nicely, to remove a bunch of boilerplate conversions.