### PR TITLE
[gateway-messages] Introduce SpStateV2

### DIFF
--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -63,7 +63,7 @@ pub const MAX_SERIALIZED_SIZE: usize = 1024;
 /// for more detail and discussion.
 pub mod version {
     pub const MIN: u32 = 2;
-    pub const CURRENT: u32 = 5;
+    pub const CURRENT: u32 = 6;
 }
 
 #[derive(

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -31,7 +31,7 @@ use crate::SpComponent;
 use crate::SpError;
 use crate::SpPort;
 use crate::SpResponse;
-use crate::SpState;
+use crate::SpStateV2;
 use crate::SpUpdatePrepare;
 use crate::StartupOptions;
 use crate::SwitchDuration;
@@ -140,7 +140,7 @@ pub trait SpHandler {
         &mut self,
         sender: SocketAddrV6,
         port: SpPort,
-    ) -> Result<SpState, SpError>;
+    ) -> Result<SpStateV2, SpError>;
 
     fn sp_update_prepare(
         &mut self,
@@ -752,7 +752,7 @@ fn handle_mgs_request<H: SpHandler>(
             .ignition_command(sender, port, target, command)
             .map(|()| SpResponse::IgnitionCommandAck),
         MgsRequest::SpState => {
-            handler.sp_state(sender, port).map(SpResponse::SpState)
+            handler.sp_state(sender, port).map(SpResponse::SpStateV2)
         }
         MgsRequest::SpUpdatePrepare(update) => handler
             .sp_update_prepare(sender, port, update)
@@ -1033,7 +1033,7 @@ mod tests {
             &mut self,
             _sender: SocketAddrV6,
             _port: SpPort,
-        ) -> Result<SpState, SpError> {
+        ) -> Result<SpStateV2, SpError> {
             unimplemented!()
         }
 

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -64,7 +64,7 @@ pub enum SpResponse {
     /// [`ignition::IgnitionState`]s.
     BulkIgnitionState(TlvPage),
     IgnitionCommandAck,
-    SpState(SpState),
+    SpState(SpStateV1),
     SpUpdatePrepareAck,
     ComponentUpdatePrepareAck,
     UpdateChunkAck,
@@ -152,7 +152,7 @@ pub struct ImageVersion {
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
 )]
-pub struct SpState {
+pub struct SpStateV1 {
     pub hubris_archive_id: [u8; 8],
     // Serial and revision are only 11 bytes in practice; we have plenty of room
     // so we'll leave the fields wider in case we grow it in the future. The
@@ -207,13 +207,6 @@ pub struct RotBootState {
     pub slot_a: Option<RotImageDetails>,
     pub slot_b: Option<RotImageDetails>,
 }
-
-/// The currently active boot slot, as well as persistent and transient boot
-/// preferences for the RoT.
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
-)]
-pub struct RotBootInfo {}
 
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -149,6 +149,8 @@ pub struct ImageVersion {
     pub version: u32,
 }
 
+/// This is quasi-deprecated in that it will only be returned by SPs with images
+/// older than the  introduction of `SpStateV2`.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
 )]

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -7,6 +7,7 @@
 use crate::tlv;
 use crate::BadRequestReason;
 use crate::PowerState;
+use crate::SlotId;
 use crate::SpComponent;
 use crate::StartupOptions;
 use crate::UpdateId;
@@ -110,6 +111,8 @@ pub enum SpResponse {
     ResetComponentTriggerAck,
     SwitchDefaultImageAck,
     ComponentActionAck,
+
+    SpStateV2(SpStateV2),
 }
 
 /// Identifier for one of of an SP's KSZ8463 management-network-facing ports.
@@ -166,6 +169,22 @@ pub struct SpState {
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
 )]
+pub struct SpStateV2 {
+    pub hubris_archive_id: [u8; 8],
+    // Serial and revision are only 11 bytes in practice; we have plenty of room
+    // so we'll leave the fields wider in case we grow it in the future. The
+    // values are 0-padded.
+    pub serial_number: [u8; 32],
+    pub model: [u8; 32],
+    pub revision: u32,
+    pub base_mac_address: [u8; 6],
+    pub power_state: PowerState,
+    pub rot: Result<RotStateV2, RotError>,
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
+)]
 pub enum RotSlot {
     A,
     B,
@@ -189,7 +208,13 @@ pub struct RotBootState {
     pub slot_b: Option<RotImageDetails>,
 }
 
-// TODO(AJS): Fill in with runtime state - i.e. updates that have completed before an RoT reset
+/// The currently active boot slot, as well as persistent and transient boot
+/// preferences for the RoT.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
+)]
+pub struct RotBootInfo {}
+
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
 )]
@@ -202,6 +227,30 @@ pub struct RotUpdateDetails {
 )]
 pub struct RotState {
     pub rot_updates: RotUpdateDetails,
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
+)]
+pub struct RotStateV2 {
+    /// The slot of the currently running image
+    pub active: SlotId,
+    /// The persistent boot preference written into the current authoritative
+    /// CFPA page (ping or pong).
+    pub persistent_boot_preference: SlotId,
+    /// The persistent boot preference written into the CFPA scratch page that
+    /// will become the persistent boot preference in the authoritative CFPA
+    /// page upon reboot, unless CFPA update of the authoritative page fails for
+    /// some reason.
+    pub pending_persistent_boot_preference: Option<SlotId>,
+    /// Override persistent preference selection for a single boot
+    ///
+    /// This is a magic ram value that is cleared by bootleby
+    pub transient_boot_preference: Option<SlotId>,
+    /// Sha3-256 Digest of Slot A in Flash
+    pub slot_a_sha3_256_digest: Option<[u8; 32]>,
+    /// Sha3-256 Digest of Slot B in Flash
+    pub slot_b_sha3_256_digest: Option<[u8; 32]>,
 }
 
 /// Metadata describing a single page (out of a larger list) of TLV-encoded
@@ -673,6 +722,8 @@ pub enum UpdateError {
     // this type. The meaning of the error code here should be found in the
     // `From<HubrisType> for MgsType` implementation in the hubris code.
     Unknown(u32),
+
+    MissingHandoffData,
 }
 
 impl fmt::Display for UpdateError {
@@ -708,6 +759,9 @@ impl fmt::Display for UpdateError {
             Self::TaskRestarted => write!(f, "hubris task restarted"),
             Self::NotImplemented => write!(f, "not implemented"),
             Self::Unknown(code) => write!(f, "unknown error (code {})", code),
+            Self::MissingHandoffData => {
+                write!(f, "boot data not handed off to hubris kernel")
+            }
         }
     }
 }

--- a/gateway-messages/tests/versioning/mod.rs
+++ b/gateway-messages/tests/versioning/mod.rs
@@ -10,6 +10,7 @@ mod v2;
 mod v3;
 mod v4;
 mod v5;
+mod v6;
 
 pub fn assert_serialized(
     out: &mut [u8],

--- a/gateway-messages/tests/versioning/v2.rs
+++ b/gateway-messages/tests/versioning/v2.rs
@@ -48,7 +48,7 @@ use gateway_messages::SpError;
 use gateway_messages::SpPort;
 use gateway_messages::SpRequest;
 use gateway_messages::SpResponse;
-use gateway_messages::SpState;
+use gateway_messages::SpStateV1;
 use gateway_messages::SpUpdatePrepare;
 use gateway_messages::StartupOptions;
 use gateway_messages::SwitchDuration;
@@ -683,7 +683,7 @@ fn sp_response() {
         for (power_state, power_state_val) in
             [(PowerState::A0, 0), (PowerState::A1, 1), (PowerState::A2, 2)]
         {
-            let response = SpResponse::SpState(SpState {
+            let response = SpResponse::SpState(SpStateV1 {
                 hubris_archive_id: [1, 2, 3, 4, 5, 6, 7, 8],
                 serial_number: [
                     9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,

--- a/gateway-messages/tests/versioning/v5.rs
+++ b/gateway-messages/tests/versioning/v5.rs
@@ -8,7 +8,7 @@
 //! If a test in this module fails, _do not change the test_! This means you
 //! have changed, deleted, or reordered an existing message type or enum
 //! variant, and you should revert that change. This will remain true until we
-//! bump the `version::MIN` to a value higher than 4, at which point these tests
+//! bump the `version::MIN` to a value higher than 5, at which point these tests
 //! can be removed as we will stop supporting v5.
 
 use super::assert_serialized;

--- a/gateway-messages/tests/versioning/v6.rs
+++ b/gateway-messages/tests/versioning/v6.rs
@@ -8,8 +8,8 @@
 //! If a test in this module fails, _do not change the test_! This means you
 //! have changed, deleted, or reordered an existing message type or enum
 //! variant, and you should revert that change. This will remain true until we
-//! bump the `version::MIN` to a value higher than 4, at which point these tests
-//! can be removed as we will stop supporting v5.
+//! bump the `version::MIN` to a value higher than 6, at which point these tests
+//! can be removed as we will stop supporting v6.
 
 use super::assert_serialized;
 use gateway_messages::RotError;

--- a/gateway-messages/tests/versioning/v6.rs
+++ b/gateway-messages/tests/versioning/v6.rs
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! The tests in this module check that the serialized form of messages from MGS
+//! protocol version 5 have not changed.
+//!
+//! If a test in this module fails, _do not change the test_! This means you
+//! have changed, deleted, or reordered an existing message type or enum
+//! variant, and you should revert that change. This will remain true until we
+//! bump the `version::MIN` to a value higher than 4, at which point these tests
+//! can be removed as we will stop supporting v5.
+
+use super::assert_serialized;
+use gateway_messages::RotError;
+use gateway_messages::RotStateV2;
+use gateway_messages::SerializedSize;
+use gateway_messages::SlotId;
+use gateway_messages::SpError;
+use gateway_messages::SpResponse;
+use gateway_messages::SpStateV2;
+use gateway_messages::UpdateError;
+
+#[test]
+fn mgs_request() {
+    let mut out = [0; SpResponse::MAX_SIZE];
+
+    let rot = RotStateV2 {
+        active: SlotId::A,
+        persistent_boot_preference: SlotId::A,
+        pending_persistent_boot_preference: Some(SlotId::B),
+        transient_boot_preference: None,
+        slot_a_sha3_256_digest: Some([0u8; 32]),
+        slot_b_sha3_256_digest: Some([0u8; 32]),
+    };
+
+    let response = SpResponse::SpStateV2(SpStateV2 {
+        hubris_archive_id: [1, 2, 3, 4, 5, 6, 7, 8],
+        serial_number: [
+            9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+            26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+        ],
+        model: [
+            41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+            58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72,
+        ],
+        revision: 0xf0f1f2f3,
+        base_mac_address: [73, 74, 75, 76, 77, 78],
+        power_state: gateway_messages::PowerState::A0,
+        rot: Ok(rot),
+    });
+
+    #[rustfmt::skip]
+    let expected = vec![
+        37, // SpState
+        1, 2, 3, 4, 5, 6, 7, 8, // hubris_archive_id
+
+        9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+        24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
+        39, 40, // serial_number
+
+        41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
+        56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
+        71, 72, // model
+
+        0xf3, 0xf2, 0xf1, 0xf0, // revision
+        73, 74, 75, 76, 77, 78, // base_mac_address
+        0, // power_state
+
+        // rot
+        0, // Ok
+        0, // active
+        0, // peristent_boot_preference
+        1,1, // pending_persistent_boot_preference
+        0, // transient_persistent_boot_preference
+        1, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+        0,0,0,0,0,0,0,0,0,0,0,0, // slot_a_sha3_256_digest
+        1, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+        0,0,0,0,0,0,0,0,0,0,0,0, // slot_b_sha3_256_digest
+    ];
+
+    assert_serialized(&mut out, &expected, &response);
+}
+
+#[test]
+fn update_error() {
+    // This variant was added in v6
+    let mut out = [0; SpResponse::MAX_SIZE];
+    let response =
+        SpResponse::Error(SpError::Update(UpdateError::MissingHandoffData));
+    let expected = vec![17, 32, 26];
+    assert_serialized(&mut out, &expected, &response);
+
+    // Test RotError variants
+    let mut out = [0; RotError::MAX_SIZE];
+    let response = RotError::Update(UpdateError::MissingHandoffData);
+    let expected = vec![4, 26];
+    assert_serialized(&mut out, &expected, &response);
+}

--- a/gateway-sp-comms/src/lib.rs
+++ b/gateway-sp-comms/src/lib.rs
@@ -25,6 +25,8 @@ pub use usdt::register_probes;
 pub mod error;
 
 pub use gateway_messages;
+pub use gateway_messages::SpState;
+pub use gateway_messages::SpStateV2;
 pub use host_phase2::HostPhase2ImageError;
 pub use host_phase2::HostPhase2Provider;
 pub use host_phase2::InMemoryHostPhase2Provider;
@@ -61,4 +63,10 @@ pub struct SwitchPortConfig {
     /// Name of the interface for this switch port. The interface should be
     /// bound to the correct VLAN tag for this port per RFD 250.
     pub interface: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub enum VersionedSpState {
+    V1(SpState),
+    V2(SpStateV2),
 }

--- a/gateway-sp-comms/src/lib.rs
+++ b/gateway-sp-comms/src/lib.rs
@@ -25,7 +25,7 @@ pub use usdt::register_probes;
 pub mod error;
 
 pub use gateway_messages;
-pub use gateway_messages::SpState;
+pub use gateway_messages::SpStateV1;
 pub use gateway_messages::SpStateV2;
 pub use host_phase2::HostPhase2ImageError;
 pub use host_phase2::HostPhase2Provider;
@@ -67,6 +67,6 @@ pub struct SwitchPortConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub enum VersionedSpState {
-    V1(SpState),
+    V1(SpStateV1),
     V2(SpStateV2),
 }

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -14,6 +14,7 @@ use crate::shared_socket::SingleSpMessage;
 use crate::sp_response_ext::SpResponseExt;
 use crate::SharedSocket;
 use crate::SwitchPortConfig;
+use crate::VersionedSpState;
 use async_trait::async_trait;
 use backoff::backoff::Backoff;
 use gateway_messages::ignition::LinkEvents;
@@ -37,7 +38,6 @@ use gateway_messages::SpError;
 use gateway_messages::SpPort;
 use gateway_messages::SpRequest;
 use gateway_messages::SpResponse;
-use gateway_messages::SpState;
 use gateway_messages::StartupOptions;
 use gateway_messages::TlvPage;
 use gateway_messages::UpdateStatus;
@@ -376,7 +376,7 @@ impl SingleSp {
     }
 
     /// Request the state of the SP.
-    pub async fn state(&self) -> Result<SpState> {
+    pub async fn state(&self) -> Result<VersionedSpState> {
         self.rpc(MgsRequest::SpState).await.and_then(
             |(_peer, response, _data)| {
                 response.expect_sp_state().map_err(Into::into)


### PR DESCRIPTION
We introduce a new response for SpState requests. By modifying the expected response in gateway-sp-comms, we can receive both the original `SpState` and `SpStateV2` responses enclosed in a new `VersionedSpState` response. Faux-mgs just prints this, but MGS can return the combined results and allow upstream callers to decide what to do. This is a general strategy for message evolution, and in some cases MGS can only return the latest version by filling in optional fields with `None` if a new field is the only thing added to the new version of the struct.

Additionally, the strategy used here makes things easy on control-plane- agent as it only has to return the latest version of the type that it knows about.