### PR TITLE
Add `UpdateStatus::RotError`

### DIFF
--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -1031,6 +1031,10 @@ async fn run_command(
                     let id = Uuid::from(id);
                     format!("update {id} failed (code={code})")
                 }
+                UpdateStatus::RotError { id, error } => {
+                    let id = Uuid::from(id);
+                    format!("update {id} failed (rot error={error:?})")
+                }
                 UpdateStatus::None => "no update status available".to_string(),
             };
             info!(log, "{status}");
@@ -1264,6 +1268,12 @@ async fn update(
                     bail!("different update failed ({id:?}, code {code})");
                 }
                 bail!("update failed (code {code})");
+            }
+            UpdateStatus::RotError { id, error } => {
+                if id != sp_update_id {
+                    bail!("different update failed ({id:?}, error {error:?})");
+                }
+                bail!("update failed (error {error:?})");
             }
         }
         tokio::time::sleep(Duration::from_secs(1)).await;

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -127,7 +127,7 @@ pub enum BadRequestReason {
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
 )]
-pub enum SlotId {
+pub enum RotSlotId {
     A,
     B,
 }

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -63,7 +63,7 @@ pub const MAX_SERIALIZED_SIZE: usize = 1024;
 /// for more detail and discussion.
 pub mod version {
     pub const MIN: u32 = 2;
-    pub const CURRENT: u32 = 6;
+    pub const CURRENT: u32 = 7;
 }
 
 #[derive(

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -7,7 +7,7 @@
 use crate::ignition::TransceiverSelect;
 use crate::BadRequestReason;
 use crate::PowerState;
-use crate::SlotId;
+use crate::RotSlotId;
 use crate::SpComponent;
 use crate::SwitchDuration;
 use crate::UpdateId;
@@ -141,7 +141,7 @@ pub enum MgsRequest {
     /// Change boot image selection on reset or power-on.
     SwitchDefaultImage {
         component: SpComponent,
-        slot: SlotId,
+        slot: RotSlotId,
         duration: SwitchDuration,
     },
 

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -25,8 +25,8 @@ use crate::MgsError;
 use crate::MgsRequest;
 use crate::MgsResponse;
 use crate::PowerState;
+use crate::RotSlotId;
 use crate::SerializedSize;
-use crate::SlotId;
 use crate::SpComponent;
 use crate::SpError;
 use crate::SpPort;
@@ -876,8 +876,8 @@ fn handle_mgs_request<H: SpHandler>(
         }
         MgsRequest::SwitchDefaultImage { component, slot, duration } => {
             let slot = match slot {
-                SlotId::A => 0,
-                SlotId::B => 1,
+                RotSlotId::A => 0,
+                RotSlotId::B => 1,
             };
             let persist = match duration {
                 SwitchDuration::Once => false,

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -413,6 +413,13 @@ pub enum UpdateStatus {
     /// update starts (or the status is reset some other way, such as an SP
     /// reboot).
     Failed { id: UpdateId, code: u32 },
+    /// Returned when an update to the RoT has failed.
+    ///
+    /// The SP has no concept of time, so we cannot indicate how recently this
+    /// abort happened. The SP will continue to return this status until a new
+    /// update starts (or the status is reset some other way, such as an SP
+    /// reboot).
+    RotError { id: UpdateId, error: RotError },
 }
 
 /// Current state when the SP is preparing to apply an update.

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -7,7 +7,7 @@
 use crate::tlv;
 use crate::BadRequestReason;
 use crate::PowerState;
-use crate::SlotId;
+use crate::RotSlotId;
 use crate::SpComponent;
 use crate::StartupOptions;
 use crate::UpdateId;
@@ -185,14 +185,6 @@ pub struct SpStateV2 {
 }
 
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
-)]
-pub enum RotSlot {
-    A,
-    B,
-}
-
-#[derive(
     Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, SerializedSize,
 )]
 pub struct RotImageDetails {
@@ -205,7 +197,7 @@ pub struct RotImageDetails {
     Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
 )]
 pub struct RotBootState {
-    pub active: RotSlot,
+    pub active: RotSlotId,
     pub slot_a: Option<RotImageDetails>,
     pub slot_b: Option<RotImageDetails>,
 }
@@ -229,19 +221,19 @@ pub struct RotState {
 )]
 pub struct RotStateV2 {
     /// The slot of the currently running image
-    pub active: SlotId,
+    pub active: RotSlotId,
     /// The persistent boot preference written into the current authoritative
     /// CFPA page (ping or pong).
-    pub persistent_boot_preference: SlotId,
+    pub persistent_boot_preference: RotSlotId,
     /// The persistent boot preference written into the CFPA scratch page that
     /// will become the persistent boot preference in the authoritative CFPA
     /// page upon reboot, unless CFPA update of the authoritative page fails for
     /// some reason.
-    pub pending_persistent_boot_preference: Option<SlotId>,
+    pub pending_persistent_boot_preference: Option<RotSlotId>,
     /// Override persistent preference selection for a single boot
     ///
     /// This is a magic ram value that is cleared by bootleby
-    pub transient_boot_preference: Option<SlotId>,
+    pub transient_boot_preference: Option<RotSlotId>,
     /// Sha3-256 Digest of Slot A in Flash
     pub slot_a_sha3_256_digest: Option<[u8; 32]>,
     /// Sha3-256 Digest of Slot B in Flash

--- a/gateway-messages/tests/versioning/mod.rs
+++ b/gateway-messages/tests/versioning/mod.rs
@@ -11,12 +11,13 @@ mod v3;
 mod v4;
 mod v5;
 mod v6;
+mod v7;
 
 pub fn assert_serialized(
     out: &mut [u8],
     expected: &[u8],
-    item: &impl Serialize,
+    item: &(impl Serialize + std::fmt::Debug),
 ) {
     let n = gateway_messages::serialize(out, item).unwrap();
-    assert_eq!(expected, &out[..n]);
+    assert_eq!(expected, &out[..n], "incorrect serialization of {item:?}");
 }

--- a/gateway-messages/tests/versioning/v2.rs
+++ b/gateway-messages/tests/versioning/v2.rs
@@ -38,11 +38,10 @@ use gateway_messages::MgsResponse;
 use gateway_messages::PowerState;
 use gateway_messages::RotBootState;
 use gateway_messages::RotImageDetails;
-use gateway_messages::RotSlot;
+use gateway_messages::RotSlotId;
 use gateway_messages::RotState;
 use gateway_messages::RotUpdateDetails;
 use gateway_messages::SerializedSize;
-use gateway_messages::SlotId;
 use gateway_messages::SpComponent;
 use gateway_messages::SpError;
 use gateway_messages::SpPort;
@@ -403,7 +402,7 @@ fn mgs_request() {
 
     let request = MgsRequest::SwitchDefaultImage {
         component: SpComponent::ROT,
-        slot: SlotId::A,
+        slot: RotSlotId::A,
         duration: SwitchDuration::Forever,
     };
     let expected =
@@ -615,7 +614,7 @@ fn sp_response() {
             Ok(RotState {
                 rot_updates: RotUpdateDetails {
                     boot_state: RotBootState {
-                        active: RotSlot::A,
+                        active: RotSlotId::A,
                         slot_a: None,
                         slot_b: None,
                     },
@@ -627,7 +626,7 @@ fn sp_response() {
             Ok(RotState {
                 rot_updates: RotUpdateDetails {
                     boot_state: RotBootState {
-                        active: RotSlot::B,
+                        active: RotSlotId::B,
                         slot_a: Some(RotImageDetails {
                             digest: [
                                 100, 101, 102, 103, 104, 105, 106, 107, 108,
@@ -655,7 +654,7 @@ fn sp_response() {
             Ok(RotState {
                 rot_updates: RotUpdateDetails {
                     boot_state: RotBootState {
-                        active: RotSlot::A,
+                        active: RotSlotId::A,
                         slot_a: None,
                         slot_b: Some(RotImageDetails {
                             digest: [

--- a/gateway-messages/tests/versioning/v6.rs
+++ b/gateway-messages/tests/versioning/v6.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 //! The tests in this module check that the serialized form of messages from MGS
-//! protocol version 5 have not changed.
+//! protocol version 6 have not changed.
 //!
 //! If a test in this module fails, _do not change the test_! This means you
 //! have changed, deleted, or reordered an existing message type or enum
@@ -13,22 +13,22 @@
 
 use super::assert_serialized;
 use gateway_messages::RotError;
+use gateway_messages::RotSlotId;
 use gateway_messages::RotStateV2;
 use gateway_messages::SerializedSize;
-use gateway_messages::SlotId;
 use gateway_messages::SpError;
 use gateway_messages::SpResponse;
 use gateway_messages::SpStateV2;
 use gateway_messages::UpdateError;
 
 #[test]
-fn mgs_request() {
+fn sp_response() {
     let mut out = [0; SpResponse::MAX_SIZE];
 
     let rot = RotStateV2 {
-        active: SlotId::A,
-        persistent_boot_preference: SlotId::A,
-        pending_persistent_boot_preference: Some(SlotId::B),
+        active: RotSlotId::A,
+        persistent_boot_preference: RotSlotId::A,
+        pending_persistent_boot_preference: Some(RotSlotId::B),
         transient_boot_preference: None,
         slot_a_sha3_256_digest: Some([0u8; 32]),
         slot_b_sha3_256_digest: Some([0u8; 32]),

--- a/gateway-messages/tests/versioning/v7.rs
+++ b/gateway-messages/tests/versioning/v7.rs
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! The tests in this module check that the serialized form of messages from MGS
+//! protocol version 7 have not changed.
+//!
+//! If a test in this module fails, _do not change the test_! This means you
+//! have changed, deleted, or reordered an existing message type or enum
+//! variant, and you should revert that change. This will remain true until we
+//! bump the `version::MIN` to a value higher than 6, at which point these tests
+//! can be removed as we will stop supporting v6.
+
+use super::assert_serialized;
+use gateway_messages::RotError;
+use gateway_messages::SerializedSize;
+use gateway_messages::SpResponse;
+use gateway_messages::SpiError;
+use gateway_messages::SprocketsError;
+use gateway_messages::SprotProtocolError;
+use gateway_messages::UpdateError;
+use gateway_messages::UpdateId;
+use gateway_messages::UpdateStatus;
+
+#[test]
+fn sp_response() {
+    let mut out = [0; SpResponse::MAX_SIZE];
+
+    // The full set of nested error serialization was tested back in v4; we'll
+    // just repeat a few of those here.
+    for (rot_error, serialized) in [
+        (
+            RotError::MessageError { code: 0x01020304 },
+            &[0_u8, 4, 3, 2, 1] as &[_],
+        ),
+        (RotError::Sprot(SprotProtocolError::InvalidCrc), &[1, 0]),
+        (RotError::Spi(SpiError::TaskRestarted), &[2, 1]),
+        (
+            RotError::Sprockets(SprocketsError::Unknown(0x05060708)),
+            &[3, 2, 8, 7, 6, 5],
+        ),
+        (RotError::Update(UpdateError::RunningImage), &[4, 15]),
+    ] {
+        let update_id = [
+            0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa,
+            0xfb, 0xfc, 0xfd, 0xfe, 0xff,
+        ];
+        let status = UpdateStatus::RotError {
+            id: UpdateId(update_id),
+            error: rot_error,
+        };
+        let response = SpResponse::UpdateStatus(status);
+        let mut expected = vec![
+            8, // SpResponse::UpdateStatus
+            7, // UpdateStatus::RotError
+        ];
+        expected.extend_from_slice(&update_id);
+        expected.extend_from_slice(serialized);
+        assert_serialized(&mut out, &expected, &response);
+    }
+}

--- a/gateway-sp-comms/src/single_sp/update.rs
+++ b/gateway-sp-comms/src/single_sp/update.rs
@@ -490,6 +490,7 @@ async fn poll_until_update_prep_complete(
             UpdateStatus::None
             | UpdateStatus::Complete(_)
             | UpdateStatus::Failed { .. }
+            | UpdateStatus::RotError { .. }
             | UpdateStatus::Aborted(_) => {
                 // Fall through to returning an error below.
             }


### PR DESCRIPTION
This will allow us to remove the placeholder ["update error 9999" in control-plane-agent](https://github.com/oxidecomputer/hubris/blob/a4b14431b2ae77ded2f55c0116cf98dad4002d38/task/control-plane-agent/src/update/rot.rs#L125-L140).

While I was here, I unified the identical enums `SlotId` and `RotSlot` into `RotSlotId`. This changes the type of some past versions, but does not change their serialized form, since both enums were identical.