### PR TITLE
Time out requests even during trampoline delivery

### DIFF
--- a/gateway-sp-comms/src/shared_socket.rs
+++ b/gateway-sp-comms/src/shared_socket.rs
@@ -417,6 +417,7 @@ enum RecvError {
 // When we receive a packet that needs to be handled by a `SingleSp` instance,
 // we look up the `SingleSp` instance by the scope ID of the source of the
 // packet then send it an instance of this enum to handle.
+#[derive(Debug, Clone)]
 pub(crate) enum SingleSpMessage {
     HostPhase2Request(HostPhase2Request),
     SerialConsole {


### PR DESCRIPTION
Prior to this change, we could fail to time out waiting for a response from an SP if we were still receiving out-of-band messages from it. During trampoline delivery, this could manifest as the SP becoming unresponsive until trampoline delivery completes; see https://github.com/oxidecomputer/management-gateway-service/issues/95.

Fixes #95.