### PR TITLE
git-based dependencies with versions can break cargo update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ resolver = "2"
 # published to crates.io
 nix = { git = "https://github.com/jgallagher/nix", branch = "r0.26-illumos" }
 
-tlvc = {git = "https://github.com/oxidecomputer/tlvc.git", version = "0.3.0"}
-hubtools = {git = "https://github.com/oxidecomputer/hubtools.git", version = "0.3.0"}
+tlvc = { git = "https://github.com/oxidecomputer/tlvc.git" }
+hubtools = { git = "https://github.com/oxidecomputer/hubtools.git" }
 
 anyhow = "1.0"
 async-trait = "0.1"
@@ -53,7 +53,7 @@ usdt = "0.3.1"
 uuid = { version = "1.1", default-features = false }
 version_check = "0.9.4"
 zerocopy = "0.6.1"
-zip = { version = "0.6.2", default-features = false, features = ["deflate","bzip2"] }
+zip = { version = "0.6.2", default-features = false, features = ["deflate", "bzip2"] }
 
 gateway-messages.path = "gateway-messages"
 gateway-sp-comms.path = "gateway-sp-comms"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.66.1"
+channel = "1.70.0"
 profile = "default"


### PR DESCRIPTION
I fell down a rabbit hole with regard to transitive dependency updates and found that `cargo update` fails on omicron:

```console
$ cargo update --dry-run
    Updating git repository `https://github.com/oxidecomputer/pq-sys`
    Updating crates.io index
    Updating git repository `https://github.com/oxidecomputer/dropshot`
...
    Updating git repository `https://github.com/jgallagher/nix`
error: failed to select a version for the requirement `hubtools = "^0.3.0"`
candidate versions found which didn't match: 0.4.1
location searched: Git repository https://github.com/oxidecomputer/hubtools.git
required by package `gateway-sp-comms v0.1.1 (https://github.com/oxidecomputer/management-gateway-service?rev=146a687f7413bfe580869bb6017f3bfe8b4710b1#146a687f)`
    ... which satisfies git dependency `gateway-sp-comms` of package `omicron-gateway v0.1.0 (/Users/ahl/src/omicron/gateway)`
    ... which satisfies path dependency `omicron-gateway` of package `sp-sim v0.1.0 (/Users/ahl/src/omicron/sp-sim)`
    ... which satisfies path dependency `sp-sim` of package `omicron-deploy v0.1.0 (/Users/ahl/src/omicron/deploy)`
```

I don't think that having the version number in Cargo.toml here is adding a significant benefit.