### PR TITLE
Add API for reading a sensor by `SensorId`

### DIFF
--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -63,7 +63,7 @@ pub const MAX_SERIALIZED_SIZE: usize = 1024;
 /// for more detail and discussion.
 pub mod version {
     pub const MIN: u32 = 2;
-    pub const CURRENT: u32 = 7;
+    pub const CURRENT: u32 = 8;
 }
 
 #[derive(

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -77,13 +77,17 @@ pub struct Header {
     pub message_id: u32,
 }
 
-#[derive(Debug, Clone, Copy, SerializedSize, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, SerializedSize, Serialize, Deserialize,
+)]
 pub struct Message {
     pub header: Header,
     pub kind: MessageKind,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, SerializedSize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Serialize, Deserialize, SerializedSize,
+)]
 pub enum MessageKind {
     MgsRequest(MgsRequest),
     MgsResponse(MgsResponse),
@@ -155,7 +159,9 @@ pub enum SensorRequest {
 }
 
 /// Most recent sensor reading, which may be a reading or a value
-#[derive(Debug, Clone, Copy, SerializedSize, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, SerializedSize, Serialize, Deserialize,
+)]
 pub struct SensorReading {
     pub value: Result<f32, SensorDataMissing>,
     pub timestamp: u64,
@@ -166,6 +172,7 @@ pub struct SensorReading {
     Debug,
     Clone,
     Copy,
+    PartialEq,
     SerializedSize,
     Serialize,
     Deserialize,

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -145,17 +145,24 @@ pub enum SwitchDuration {
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
 )]
-pub enum SensorRequest {
-    /// Requests the current timestamp (as a `u64`)
-    CurrentTime,
+pub enum SensorRequestKind {
     /// Requests the most recent reading, which is either a value or error
-    LastReading { id: u32 },
+    LastReading,
     /// Requests the most recent data value
-    LastData { id: u32 },
+    LastData,
     /// Requests the most recent error value
-    LastError { id: u32 },
+    LastError,
     /// Requests the error count for a given sensor
-    ErrorCount { id: u32 },
+    ErrorCount,
+}
+
+/// Sensor readings that we could request from the target by `SensorId`
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
+)]
+pub struct SensorRequest {
+    pub kind: SensorRequestKind,
+    pub id: u32,
 }
 
 /// Most recent sensor reading, which may be a reading or a value
@@ -180,7 +187,6 @@ pub struct SensorReading {
 )]
 #[strum(serialize_all = "snake_case")]
 pub enum SensorResponse {
-    CurrentTime(u64),
     LastReading(SensorReading),
     LastData { value: f32, timestamp: u64 },
     LastError { value: SensorDataMissing, timestamp: u64 },

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -77,17 +77,13 @@ pub struct Header {
     pub message_id: u32,
 }
 
-#[derive(
-    Debug, Clone, Copy, SerializedSize, Serialize, Deserialize, PartialEq, Eq,
-)]
+#[derive(Debug, Clone, Copy, SerializedSize, Serialize, Deserialize)]
 pub struct Message {
     pub header: Header,
     pub kind: MessageKind,
 }
 
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, SerializedSize,
-)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, SerializedSize)]
 pub enum MessageKind {
     MgsRequest(MgsRequest),
     MgsResponse(MgsResponse),
@@ -139,6 +135,63 @@ pub enum RotSlotId {
 pub enum SwitchDuration {
     Once,
     Forever,
+}
+
+/// Sensor readings that we could request from the target by `SensorId`
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
+)]
+pub enum SensorRequest {
+    /// Requests the current timestamp (as a `u64`)
+    CurrentTime,
+    /// Requests the most recent reading, which is either a value or error
+    LastReading { id: u32 },
+    /// Requests the most recent data value
+    LastData { id: u32 },
+    /// Requests the most recent error value
+    LastError { id: u32 },
+    /// Requests the error count for a given sensor
+    ErrorCount { id: u32 },
+}
+
+/// Most recent sensor reading, which may be a reading or a value
+#[derive(Debug, Clone, Copy, SerializedSize, Serialize, Deserialize)]
+pub struct SensorReading {
+    pub value: Result<f32, SensorDataMissing>,
+    pub timestamp: u64,
+}
+
+/// Response to a [`SensorRequest`]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    SerializedSize,
+    Serialize,
+    Deserialize,
+    strum_macros::IntoStaticStr,
+)]
+#[strum(serialize_all = "snake_case")]
+pub enum SensorResponse {
+    CurrentTime(u64),
+    LastReading(SensorReading),
+    LastData { value: f32, timestamp: u64 },
+    LastError { value: SensorDataMissing, timestamp: u64 },
+    ErrorCount(u32),
+}
+
+/// An error or issue that led to sensor data not being available
+///
+/// Equivalent to `NoData` in Hubris.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
+)]
+pub enum SensorDataMissing {
+    DeviceOff,
+    DeviceError,
+    DeviceNotPresent,
+    DeviceUnavailable,
+    DeviceTimeout,
 }
 
 #[derive(

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -160,7 +160,11 @@ pub enum MgsRequest {
         key: [u8; 4],
     },
 
+    /// Issues a sensor read request
     ReadSensor(SensorRequest),
+
+    /// Requests the target's current time (usually milliseconds since boot)
+    CurrentTime,
 }
 
 #[derive(

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -8,6 +8,7 @@ use crate::ignition::TransceiverSelect;
 use crate::BadRequestReason;
 use crate::PowerState;
 use crate::RotSlotId;
+use crate::SensorRequest;
 use crate::SpComponent;
 use crate::SwitchDuration;
 use crate::UpdateId;
@@ -158,6 +159,8 @@ pub enum MgsRequest {
         slot: u16,
         key: [u8; 4],
     },
+
+    ReadSensor(SensorRequest),
 }
 
 #[derive(

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -380,6 +380,8 @@ pub trait SpHandler {
         &mut self,
         request: SensorRequest,
     ) -> Result<SensorResponse, SpError>;
+
+    fn current_time(&mut self) -> Result<u64, SpError>;
 }
 
 /// Handle a single incoming message.
@@ -926,6 +928,9 @@ fn handle_mgs_request<H: SpHandler>(
         MgsRequest::ReadSensor(req) => {
             handler.read_sensor(req).map(SpResponse::ReadSensor)
         }
+        MgsRequest::CurrentTime => {
+            handler.current_time().map(SpResponse::CurrentTime)
+        }
     };
 
     let response = match result {
@@ -1309,6 +1314,10 @@ mod tests {
             &mut self,
             _r: SensorRequest,
         ) -> Result<SensorResponse, SpError> {
+            unimplemented!()
+        }
+
+        fn current_time(&mut self) -> Result<u64, SpError> {
             unimplemented!()
         }
     }

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -26,6 +26,8 @@ use crate::MgsRequest;
 use crate::MgsResponse;
 use crate::PowerState;
 use crate::RotSlotId;
+use crate::SensorRequest;
+use crate::SensorResponse;
 use crate::SerializedSize;
 use crate::SpComponent;
 use crate::SpError;
@@ -373,6 +375,11 @@ pub trait SpHandler {
         port: SpPort,
         component: SpComponent,
     ) -> Result<(), SpError>;
+
+    fn read_sensor(
+        &mut self,
+        request: SensorRequest,
+    ) -> Result<SensorResponse, SpError>;
 }
 
 /// Handle a single incoming message.
@@ -915,6 +922,9 @@ fn handle_mgs_request<H: SpHandler>(
                     Some(OutgoingTrailingData::ShiftFromTail(n));
             }
             r.map(|_| SpResponse::CabooseValue)
+        }
+        MgsRequest::ReadSensor(req) => {
+            handler.read_sensor(req).map(SpResponse::ReadSensor)
         }
     };
 

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -1304,6 +1304,13 @@ mod tests {
         ) -> Result<usize, SpError> {
             unimplemented!()
         }
+
+        fn read_sensor(
+            &mut self,
+            _r: SensorRequest,
+        ) -> Result<SensorResponse, SpError> {
+            unimplemented!()
+        }
     }
 
     #[cfg(feature = "std")]

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -59,6 +59,7 @@ pub enum SpRequest {
     Debug,
     Clone,
     Copy,
+    PartialEq,
     SerializedSize,
     Serialize,
     Deserialize,

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -457,7 +457,7 @@ pub struct UpdateInProgressStatus {
 }
 
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
+    Debug, Clone, Copy, PartialEq, SerializedSize, Serialize, Deserialize,
 )]
 pub enum SpError {
     /// The SP is busy; retry the request mometarily.
@@ -550,6 +550,7 @@ pub enum SpError {
     Spi(SpiError),
     Sprockets(SprocketsError),
     Update(UpdateError),
+    Sensor(SensorError),
 }
 
 impl fmt::Display for SpError {
@@ -659,6 +660,7 @@ impl fmt::Display for SpError {
             Self::Spi(e) => write!(f, "spi: {}", e),
             Self::Sprockets(e) => write!(f, "sprockets: {}", e),
             Self::Update(e) => write!(f, "update: {}", e),
+            Self::Sensor(e) => write!(f, "sensor: {}", e),
         }
     }
 }
@@ -934,3 +936,27 @@ impl fmt::Display for RotError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for RotError {}
+
+/// Sensor errors encountered during a read
+///
+/// This value is wrapped by [`SpError`]; note that it is distinct from
+/// [`crate::SensorDataMissing`]!
+#[derive(
+    Debug, Clone, Copy, PartialEq, SerializedSize, Serialize, Deserialize,
+)]
+pub enum SensorError {
+    InvalidSensor,
+    NoReading,
+}
+
+impl fmt::Display for SensorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidSensor => write!(f, "sensor ID is invalid"),
+            Self::NoReading => write!(f, "reading is not present"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for SensorError {}

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -123,6 +123,7 @@ pub enum SpResponse {
 
     SpStateV2(SpStateV2),
     ReadSensor(SensorResponse),
+    CurrentTime(u64),
 }
 
 /// Identifier for one of of an SP's KSZ8463 management-network-facing ports.

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -8,6 +8,7 @@ use crate::tlv;
 use crate::BadRequestReason;
 use crate::PowerState;
 use crate::RotSlotId;
+use crate::SensorResponse;
 use crate::SpComponent;
 use crate::StartupOptions;
 use crate::UpdateId;
@@ -61,8 +62,6 @@ pub enum SpRequest {
     SerializedSize,
     Serialize,
     Deserialize,
-    PartialEq,
-    Eq,
     strum_macros::IntoStaticStr,
 )]
 #[strum(serialize_all = "snake_case")]
@@ -122,6 +121,7 @@ pub enum SpResponse {
     ComponentActionAck,
 
     SpStateV2(SpStateV2),
+    ReadSensor(SensorResponse),
 }
 
 /// Identifier for one of of an SP's KSZ8463 management-network-facing ports.

--- a/gateway-messages/tests/versioning/mod.rs
+++ b/gateway-messages/tests/versioning/mod.rs
@@ -12,6 +12,7 @@ mod v4;
 mod v5;
 mod v6;
 mod v7;
+mod v8;
 
 pub fn assert_serialized(
     out: &mut [u8],

--- a/gateway-messages/tests/versioning/v8.rs
+++ b/gateway-messages/tests/versioning/v8.rs
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! The tests in this module check that the serialized form of messages from MGS
+//! protocol version 8 have not changed.
+//!
+//! If a test in this module fails, _do not change the test_! This means you
+//! have changed, deleted, or reordered an existing message type or enum
+//! variant, and you should revert that change. This will remain true until we
+//! bump the `version::MIN` to a value higher than 8, at which point these tests
+//! can be removed as we will stop supporting v8.
+
+use super::assert_serialized;
+use gateway_messages::SensorDataMissing;
+use gateway_messages::SensorReading;
+use gateway_messages::SensorResponse;
+use gateway_messages::SerializedSize;
+use gateway_messages::SpResponse;
+
+#[test]
+fn sp_response() {
+    let mut out = [0; SpResponse::MAX_SIZE];
+    for (response, serialized) in [
+        (
+            SensorResponse::CurrentTime(0x1234),
+            &[0_u8, 0x34, 0x12, 0, 0, 0, 0, 0, 0] as &[_],
+        ),
+        (
+            SensorResponse::LastReading(SensorReading {
+                value: Ok(1.0),
+                timestamp: 0x5566,
+            }),
+            &[1, 0, 0, 0, 0x80, 0x3f, 0x66, 0x55, 0, 0, 0, 0, 0, 0],
+        ),
+        (
+            SensorResponse::LastData { value: 1.0, timestamp: 0x5566 },
+            &[2, 0, 0, 0x80, 0x3f, 0x66, 0x55, 0, 0, 0, 0, 0, 0],
+        ),
+        (
+            SensorResponse::LastError {
+                value: SensorDataMissing::DeviceOff,
+                timestamp: 0x5566,
+            },
+            &[3, 0, 0x66, 0x55, 0, 0, 0, 0, 0, 0],
+        ),
+        (SensorResponse::ErrorCount(0x12345678), &[4, 0x78, 0x56, 0x34, 0x12]),
+    ] {
+        let response = SpResponse::ReadSensor(response);
+        let mut expected = vec![
+            38, // SpResponse::ReadSensor
+        ];
+        expected.extend_from_slice(serialized);
+        assert_serialized(&mut out, &expected, &response);
+    }
+}
+
+#[test]
+fn sensor_data_missing() {
+    let mut out = [0; SensorDataMissing::MAX_SIZE];
+
+    assert_serialized(&mut out, &[0], &SensorDataMissing::DeviceOff);
+    assert_serialized(&mut out, &[1], &SensorDataMissing::DeviceError);
+    assert_serialized(&mut out, &[2], &SensorDataMissing::DeviceNotPresent);
+    assert_serialized(&mut out, &[3], &SensorDataMissing::DeviceUnavailable);
+    assert_serialized(&mut out, &[4], &SensorDataMissing::DeviceTimeout);
+}

--- a/gateway-messages/tests/versioning/v8.rs
+++ b/gateway-messages/tests/versioning/v8.rs
@@ -12,8 +12,10 @@
 //! can be removed as we will stop supporting v8.
 
 use super::assert_serialized;
+use gateway_messages::MgsRequest;
 use gateway_messages::SensorDataMissing;
 use gateway_messages::SensorReading;
+use gateway_messages::SensorRequest;
 use gateway_messages::SensorResponse;
 use gateway_messages::SerializedSize;
 use gateway_messages::SpResponse;
@@ -47,6 +49,25 @@ fn sp_response() {
         (SensorResponse::ErrorCount(0x12345678), &[4, 0x78, 0x56, 0x34, 0x12]),
     ] {
         let response = SpResponse::ReadSensor(response);
+        let mut expected = vec![
+            38, // SpResponse::ReadSensor
+        ];
+        expected.extend_from_slice(serialized);
+        assert_serialized(&mut out, &expected, &response);
+    }
+}
+
+#[test]
+fn host_request() {
+    let mut out = [0; MgsRequest::MAX_SIZE];
+    for (request, serialized) in [
+        (SensorRequest::CurrentTime, &[0_u8] as &[_]),
+        (SensorRequest::LastReading { id: 0x1234 }, &[1, 0x34, 0x12, 0, 0]),
+        (SensorRequest::LastData { id: 0x1234 }, &[2, 0x34, 0x12, 0, 0]),
+        (SensorRequest::LastError { id: 0x1234 }, &[3, 0x34, 0x12, 0, 0]),
+        (SensorRequest::ErrorCount { id: 0x1234 }, &[4, 0x34, 0x12, 0, 0]),
+    ] {
+        let response = MgsRequest::ReadSensor(request);
         let mut expected = vec![
             38, // SpResponse::ReadSensor
         ];

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -33,6 +33,9 @@ use gateway_messages::Message;
 use gateway_messages::MessageKind;
 use gateway_messages::MgsRequest;
 use gateway_messages::PowerState;
+use gateway_messages::SensorReading;
+use gateway_messages::SensorRequest;
+use gateway_messages::SensorResponse;
 use gateway_messages::SpComponent;
 use gateway_messages::SpError;
 use gateway_messages::SpPort;
@@ -792,6 +795,22 @@ impl SingleSp {
         .await;
 
         result.result.and_then(expect_caboose_value)
+    }
+
+    pub async fn read_sensor_value(&self, id: u32) -> Result<SensorReading> {
+        let v = self
+            .rpc(MgsRequest::ReadSensor(SensorRequest::LastReading { id }))
+            .await
+            .and_then(expect_read_sensor)?;
+        match v {
+            SensorResponse::LastReading(r) => Ok(r),
+            // TODO: Is this a bad overloading of
+            // CommunicationError::BadResponseType?
+            other => Err(CommunicationError::BadResponseType {
+                expected: "last_reading",
+                got: other.into(),
+            }),
+        }
     }
 }
 

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -35,6 +35,7 @@ use gateway_messages::MgsRequest;
 use gateway_messages::PowerState;
 use gateway_messages::SensorReading;
 use gateway_messages::SensorRequest;
+use gateway_messages::SensorRequestKind;
 use gateway_messages::SensorResponse;
 use gateway_messages::SpComponent;
 use gateway_messages::SpError;
@@ -799,7 +800,10 @@ impl SingleSp {
 
     pub async fn read_sensor_value(&self, id: u32) -> Result<SensorReading> {
         let v = self
-            .rpc(MgsRequest::ReadSensor(SensorRequest::LastReading { id }))
+            .rpc(MgsRequest::ReadSensor(SensorRequest {
+                kind: SensorRequestKind::LastReading,
+                id,
+            }))
             .await
             .and_then(expect_read_sensor)?;
         match v {

--- a/gateway-sp-comms/src/sp_response_expect.rs
+++ b/gateway-sp-comms/src/sp_response_expect.rs
@@ -113,6 +113,7 @@ expect_fn!(ResetComponentTriggerAck);
 expect_fn!(SwitchDefaultImageAck);
 expect_fn!(ComponentActionAck);
 expect_fn!(ReadSensor(resp) -> SensorResponse);
+expect_fn!(CurrentTime(time) -> u64);
 
 // Data-bearing responses
 expect_data_fn!(BulkIgnitionState(page) -> TlvPage);

--- a/gateway-sp-comms/src/sp_response_expect.rs
+++ b/gateway-sp-comms/src/sp_response_expect.rs
@@ -8,6 +8,7 @@ use gateway_messages::ignition::LinkEvents;
 use gateway_messages::DiscoverResponse;
 use gateway_messages::IgnitionState;
 use gateway_messages::PowerState;
+use gateway_messages::SensorResponse;
 use gateway_messages::SpResponse;
 use gateway_messages::StartupOptions;
 use gateway_messages::TlvPage;
@@ -111,6 +112,7 @@ expect_fn!(ResetComponentPrepareAck);
 expect_fn!(ResetComponentTriggerAck);
 expect_fn!(SwitchDefaultImageAck);
 expect_fn!(ComponentActionAck);
+expect_fn!(ReadSensor(resp) -> SensorResponse);
 
 // Data-bearing responses
 expect_data_fn!(BulkIgnitionState(page) -> TlvPage);


### PR DESCRIPTION
The current plan for metrics is to have IPCC report Hubris sensor IDs as part of its device inventory.  Then, the host will use MGS – with the messages introduced in this PR – to collect data for metrics.

The PR is quite flexible; it adds a new `ReadSensor` message which allows for a bunch of different sub-requests.

(This sidesteps the existing per-MGS-component sensor implementation, which predates the current plan and isn't widely used.  I talked with John about this in advance, and we're in agreement

TODO:
- [x] Bump MGS message version and add exhaustive tests