### PR TITLE
Add SprotProtocolError::Desynchronized

### DIFF
--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -63,7 +63,7 @@ pub const MAX_SERIALIZED_SIZE: usize = 1024;
 /// for more detail and discussion.
 pub mod version {
     pub const MIN: u32 = 2;
-    pub const CURRENT: u32 = 10;
+    pub const CURRENT: u32 = 9;
 }
 
 #[derive(

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -63,7 +63,7 @@ pub const MAX_SERIALIZED_SIZE: usize = 1024;
 /// for more detail and discussion.
 pub mod version {
     pub const MIN: u32 = 2;
-    pub const CURRENT: u32 = 8;
+    pub const CURRENT: u32 = 10;
 }
 
 #[derive(

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -828,27 +828,27 @@ pub enum SprotProtocolError {
     BadMessageLength,
     // We cannot assert chip select
     CannotAssertCSn,
-    // The request timed out
+    /// The request timed out
     Timeout,
-    // Hubpack error
+    /// Hubpack error
     Deserialization,
-    // The RoT has not de-asserted ROT_IRQ
+    /// The RoT has not de-asserted ROT_IRQ
     RotIrqRemainsAsserted,
-    // An unexpected response was received.
-    // This should basically be impossible. We only include it so we can
-    // return this error when unpacking a RspBody in idol calls.
+    /// An unexpected response was received.
+    /// This should basically be impossible. We only include it so we can
+    /// return this error when unpacking a RspBody in idol calls.
     UnexpectedResponse,
-
-    // Failed to load update status
+    /// Failed to load update status
     BadUpdateStatus,
-
-    // Used for mapping From<idol_runtime::ServerDeath>
+    /// Used for mapping From<idol_runtime::ServerDeath>
     TaskRestarted,
-
-    // When the type in hubris has been updated, but MGS does not yet know
-    // this type. The meaning of the error code here should be found in the
-    // `From<HubrisType> for MgsType` implementation in the hubris code.
+    /// When the type in hubris has been updated, but MGS does not yet know
+    /// this type. The meaning of the error code here should be found in the
+    /// `From<HubrisType> for MgsType` implementation in the hubris code.
     Unknown(u32),
+    /// The SP and RoT did not agree on whether the SP is sending a request or
+    /// waiting for a reply
+    Desynchronized,
 }
 
 impl fmt::Display for SprotProtocolError {
@@ -873,6 +873,7 @@ impl fmt::Display for SprotProtocolError {
             Self::BadUpdateStatus => write!(f, "failed to load update status"),
             Self::TaskRestarted => write!(f, "hubris task restarted"),
             Self::Unknown(code) => write!(f, "unknown error (code {})", code),
+            Self::Desynchronized => write!(f, "SP and RoT are desynchronized"),
         }
     }
 }

--- a/gateway-messages/tests/versioning/mod.rs
+++ b/gateway-messages/tests/versioning/mod.rs
@@ -13,8 +13,7 @@ mod v5;
 mod v6;
 mod v7;
 mod v8;
-
-mod v10;
+mod v9;
 
 pub fn assert_serialized(
     out: &mut [u8],

--- a/gateway-messages/tests/versioning/mod.rs
+++ b/gateway-messages/tests/versioning/mod.rs
@@ -14,6 +14,8 @@ mod v6;
 mod v7;
 mod v8;
 
+mod v10;
+
 pub fn assert_serialized(
     out: &mut [u8],
     expected: &[u8],

--- a/gateway-messages/tests/versioning/v10.rs
+++ b/gateway-messages/tests/versioning/v10.rs
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! The tests in this module check that the serialized form of messages from MGS
+//! protocol version 10 have not changed.
+//!
+//! If a test in this module fails, _do not change the test_! This means you
+//! have changed, deleted, or reordered an existing message type or enum
+//! variant, and you should revert that change. This will remain true until we
+//! bump the `version::MIN` to a value higher than 10, at which point these tests
+//! can be removed as we will stop supporting v10.
+
+use super::assert_serialized;
+use gateway_messages::MgsRequest;
+use gateway_messages::RotError;
+use gateway_messages::SerializedSize;
+use gateway_messages::SpError;
+use gateway_messages::SpResponse;
+use gateway_messages::SprotProtocolError;
+
+// Test SprotProtocolError
+#[test]
+fn sprot_protocol_errors() {
+    let mut out = [0; MgsRequest::MAX_SIZE];
+
+    for (error, serialized) in [
+        (SprotProtocolError::InvalidCrc, &[0_u8] as &[_]),
+        (SprotProtocolError::FlowError, &[1]),
+        (SprotProtocolError::UnsupportedProtocol, &[2]),
+        (SprotProtocolError::BadMessageType, &[3]),
+        (SprotProtocolError::BadMessageLength, &[4]),
+        (SprotProtocolError::CannotAssertCSn, &[5]),
+        (SprotProtocolError::Timeout, &[6]),
+        (SprotProtocolError::Deserialization, &[7]),
+        (SprotProtocolError::RotIrqRemainsAsserted, &[8]),
+        (SprotProtocolError::UnexpectedResponse, &[9]),
+        (SprotProtocolError::BadUpdateStatus, &[10]),
+        (SprotProtocolError::TaskRestarted, &[11]),
+        (
+            SprotProtocolError::Unknown(0xABCDEFAB),
+            // little endian
+            &[12, 0xAB, 0xEF, 0xCD, 0xAB],
+        ),
+        (SprotProtocolError::Desynchronized, &[13]),
+    ] {
+        // Test SpError variants encoded in an SpResponse
+        let response = SpResponse::Error(SpError::Sprot(error));
+        let mut expected = vec![17, 29];
+        expected.extend_from_slice(serialized);
+        assert_serialized(&mut out, &expected, &response);
+
+        // Test RotError variants
+        let response = RotError::Sprot(error);
+        let mut expected = vec![1];
+        expected.extend_from_slice(serialized);
+        assert_serialized(&mut out, &expected, &response);
+    }
+}

--- a/gateway-messages/tests/versioning/v9.rs
+++ b/gateway-messages/tests/versioning/v9.rs
@@ -3,13 +3,13 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 //! The tests in this module check that the serialized form of messages from MGS
-//! protocol version 10 have not changed.
+//! protocol version 9 have not changed.
 //!
 //! If a test in this module fails, _do not change the test_! This means you
 //! have changed, deleted, or reordered an existing message type or enum
 //! variant, and you should revert that change. This will remain true until we
-//! bump the `version::MIN` to a value higher than 10, at which point these tests
-//! can be removed as we will stop supporting v10.
+//! bump the `version::MIN` to a value higher than 9, at which point these tests
+//! can be removed as we will stop supporting v9.
 
 use super::assert_serialized;
 use gateway_messages::MgsRequest;


### PR DESCRIPTION
This is an error type that will be plumbed up from the RoT. This change should be merged after #116, as it bumps the version to `v10`, where that #116 bumps it to `v9`.