### PR TITLE
Use slog-error-chain for error formatting and logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,6 @@ dependencies = [
  "slog-async",
  "slog-term",
  "termios",
- "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -672,6 +671,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "slog",
+ "slog-error-chain",
  "socket2 0.5.5",
  "string_cache",
  "thiserror",
@@ -1668,6 +1668,25 @@ dependencies = [
  "slog",
  "take_mut",
  "thread_local",
+]
+
+[[package]]
+name = "slog-error-chain"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/slog-error-chain.git?branch=main#15f69041f45774602108e47fb25e705dc23acfb2"
+dependencies = [
+ "slog",
+ "slog-error-chain-derive",
+]
+
+[[package]]
+name = "slog-error-chain-derive"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/slog-error-chain.git?branch=main#15f69041f45774602108e47fb25e705dc23acfb2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ resolver = "2"
 [workspace.dependencies]
 tlvc = { git = "https://github.com/oxidecomputer/tlvc.git", branch = "main" }
 hubtools = { git = "https://github.com/oxidecomputer/hubtools.git", branch = "main"}
+slog-error-chain = { git = "https://github.com/oxidecomputer/slog-error-chain.git", branch = "main", features = ["derive"] }
 
 anyhow = "1.0"
 async-trait = "0.1"

--- a/faux-mgs/Cargo.toml
+++ b/faux-mgs/Cargo.toml
@@ -19,7 +19,6 @@ slog.workspace = true
 slog-async.workspace = true
 slog-term.workspace = true
 termios.workspace = true
-thiserror.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 tokio-util.workspace = true

--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -1447,7 +1447,7 @@ async fn populate_phase2_images(
                 warn!(
                     log, "skipping file (not a phase2 image?)";
                     "path" => entry_path.display(),
-                    "err" => %err,
+                    err,
                 );
             }
         }

--- a/faux-mgs/src/usart.rs
+++ b/faux-mgs/src/usart.rs
@@ -129,10 +129,7 @@ pub(crate) async fn run(
                 // case it first sends a message on this channel).
                 let fatal_err = fatal_err_result
                     .expect("tx_to_sp task panicked");
-                error!(
-                    log, "fatal communication error with SP";
-                    "err" => #%fatal_err,
-                );
+                error!(log, "fatal communication error with SP"; fatal_err);
                 encountered_fatal_error = true;
                 break;
             }
@@ -269,10 +266,7 @@ async fn relay_data_to_sp(
                         keepalive.reset();
                     }
                     Err(err) => {
-                        warn!(
-                            log, "failed to send console keepalive";
-                            "err" => #%err,
-                        );
+                        warn!(log, "failed to send console keepalive"; err);
                     }
                 }
             }
@@ -320,7 +314,7 @@ async fn drain_messages_to_send(
             Err(non_fatal_err) => {
                 warn!(
                     log, "communication error with SP (will retry)";
-                    "err" => #%non_fatal_err,
+                    non_fatal_err,
                 );
                 *recently_warned = true;
                 return Ok(());

--- a/gateway-sp-comms/Cargo.toml
+++ b/gateway-sp-comms/Cargo.toml
@@ -19,6 +19,7 @@ paste.workspace = true
 serde.workspace = true
 serde-big-array.workspace = true
 slog.workspace = true
+slog-error-chain.workspace = true
 socket2.workspace = true
 string_cache.workspace = true
 thiserror.workspace = true

--- a/gateway-sp-comms/src/error.rs
+++ b/gateway-sp-comms/src/error.rs
@@ -6,6 +6,7 @@
 
 use gateway_messages::tlv;
 use gateway_messages::SpError;
+use slog_error_chain::SlogInlineError;
 use std::io;
 use std::net::Ipv6Addr;
 use std::net::SocketAddrV6;
@@ -14,7 +15,7 @@ use thiserror::Error;
 pub use crate::scope_id_cache::InterfaceError;
 use crate::shared_socket::SingleSpHandleError;
 
-#[derive(Debug, Clone, Error)]
+#[derive(Debug, Clone, Error, SlogInlineError)]
 pub enum HostPhase2Error {
     #[error("host image with hash {hash} unavailable")]
     NoImage { hash: String },
@@ -26,7 +27,7 @@ pub enum HostPhase2Error {
     Other { hash: String, offset: u64, err: String },
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, SlogInlineError)]
 pub enum CommunicationError {
     #[error(transparent)]
     InterfaceError(#[from] InterfaceError),
@@ -46,7 +47,7 @@ pub enum CommunicationError {
     ExhaustedNumAttempts(usize),
     #[error("bogus SP response type: expected {expected:?} but got {got:?}")]
     BadResponseType { expected: &'static str, got: &'static str },
-    #[error("Error response from SP: {0}")]
+    #[error("Error response from SP")]
     SpError(#[from] SpError),
     #[error("Bogus serial console state; detach and reattach")]
     BogusSerialConsoleState,
@@ -54,7 +55,7 @@ pub enum CommunicationError {
     VersionMismatch { sp: u32, mgs: u32 },
     #[error("failed to deserialize TLV value for tag {tag:?}: {err}")]
     TlvDeserialize { tag: tlv::Tag, err: gateway_messages::HubpackError },
-    #[error("failed to decode TLV triple: {0}")]
+    #[error("failed to decode TLV triple")]
     TlvDecode(#[from] tlv::DecodeError),
     #[error("invalid pagination: {reason}")]
     TlvPagination { reason: &'static str },
@@ -83,7 +84,7 @@ impl From<SingleSpHandleError> for CommunicationError {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, SlogInlineError)]
 pub enum UpdateError {
     #[error("update image cannot be empty")]
     ImageEmpty,

--- a/gateway-sp-comms/src/host_phase2.rs
+++ b/gateway-sp-comms/src/host_phase2.rs
@@ -10,6 +10,7 @@ use hubpack::SerializedSize;
 use lru_cache::LruCache;
 use serde::Deserialize;
 use serde_big_array::BigArray;
+use slog_error_chain::SlogInlineError;
 use std::convert::TryFrom;
 use std::sync::Arc;
 use thiserror::Error;
@@ -17,9 +18,9 @@ use tokio::sync::Mutex;
 
 type Sha256Digest = [u8; 32];
 
-#[derive(Debug, Clone, Copy, Error)]
+#[derive(Debug, Clone, Copy, Error, SlogInlineError)]
 pub enum HostPhase2ImageError {
-    #[error("could not deserialize image header: {0}")]
+    #[error("could not deserialize image header")]
     DeserializeHeader(#[from] hubpack::error::Error),
     #[error(
         "incorrect magic in image header (expected {expected:#x}, got {got:#x})"

--- a/gateway-sp-comms/src/scope_id_cache.rs
+++ b/gateway-sp-comms/src/scope_id_cache.rs
@@ -10,18 +10,23 @@ use fxhash::FxHashMap;
 use nix::libc::c_uint;
 use nix::net::if_::if_nameindex;
 use nix::net::if_::if_nametoindex;
+use slog_error_chain::SlogInlineError;
 use std::fmt;
 use std::ops::Deref;
 use string_cache::DefaultAtom;
 use thiserror::Error;
 use tokio::sync::Mutex;
 
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[derive(Debug, Clone, PartialEq, Eq, Error, SlogInlineError)]
 pub enum InterfaceError {
-    #[error("if_nametoindex({name:?}) failed: {err}")]
-    IfNameToIndex { name: String, err: nix::Error },
-    #[error("if_nameindex() failed: {0}")]
-    IfNameIndex(nix::Error),
+    #[error("if_nametoindex({name:?}) failed")]
+    IfNameToIndex {
+        name: String,
+        #[source]
+        err: nix::Error,
+    },
+    #[error("if_nameindex() failed")]
+    IfNameIndex(#[source] nix::Error),
     #[error("non-UTF8 interface: {0:?}")]
     NonUtf8Interface(Vec<u8>),
     #[error("no interface name found for index {0}")]

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -1595,7 +1595,7 @@ impl<T: InnerSocket> Inner<T> {
                         Err(err) => {
                             warn!(
                                 self.log(), "idle discovery check failed";
-                                "err" => %err,
+                                err,
                             );
                         }
                     }
@@ -1627,8 +1627,8 @@ impl<T: InnerSocket> Inner<T> {
                     info!(
                         self.log(),
                         "initial discovery failed";
-                        "err" => %err,
                         "addr" => %self.socket_handle.discovery_addr(),
+                        err,
                     );
                 }
             }

--- a/gateway-sp-comms/src/single_sp/update.rs
+++ b/gateway-sp-comms/src/single_sp/update.rs
@@ -193,7 +193,7 @@ async fn drive_sp_update(
                 error!(
                     log, "aux flash update failed";
                     "id" => %update_id,
-                    "err" => %err,
+                    err,
                 );
                 return;
             }
@@ -217,7 +217,7 @@ async fn drive_sp_update(
             error!(
                 log, "update failed";
                 "id" => %update_id,
-                "err" => %err,
+                err,
             );
         }
     }
@@ -398,7 +398,7 @@ async fn drive_component_update(
             error!(
                 log, "update failed";
                 "id" => %update_id,
-                "err" => %err,
+                err,
             );
         }
     }


### PR DESCRIPTION
Corrects usages of `#[from]` and `#[source]` with embedded error strings as described in [slog-error-chain](https://github.com/oxidecomputer/slog-error-chain?tab=readme-ov-file#aside-embedding-source-error-strings), and uses that crate to add `slog::{KV,Value}` impls to all our error types.

Goodbye

```
Error: Error response from SP: the image caboose does not contain 'NONE': the image caboose does not contain 'NONE'
```

Hello

```
Error: Error response from SP: the image caboose does not contain 'NONE'
```