### PR TITLE
Update stage0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "faux-mgs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/faux-mgs/Cargo.toml
+++ b/faux-mgs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faux-mgs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MPL-2.0"
 

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -66,7 +66,7 @@ pub const ROT_PAGE_SIZE: usize = 512;
 /// for more detail and discussion.
 pub mod version {
     pub const MIN: u32 = 2;
-    pub const CURRENT: u32 = 12;
+    pub const CURRENT: u32 = 13;
 
     /// MGS protocol version in which SP watchdog messages were added
     pub const WATCHDOG_VERSION: u32 = 12;
@@ -129,7 +129,7 @@ pub enum BadRequestReason {
     DeserializationError,
 }
 
-/// Image slot name for SwitchDefaultImage
+/// Image slot name for SwitchDefaultImage on component ROT
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, SerializedSize, Serialize, Deserialize,
 )]

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -204,6 +204,11 @@ pub enum MgsRequest {
     ComponentWatchdogSupported {
         component: SpComponent,
     },
+
+    /// Read RoT boot state at the highest version not to exceed specified version.
+    VersionedRotBootInfo {
+        version: u8,
+    },
 }
 
 #[derive(

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -25,6 +25,7 @@ use crate::MgsError;
 use crate::MgsRequest;
 use crate::MgsResponse;
 use crate::PowerState;
+use crate::RotBootInfo;
 use crate::RotRequest;
 use crate::RotResponse;
 use crate::RotSlotId;
@@ -412,6 +413,13 @@ pub trait SpHandler {
         &mut self,
         component: SpComponent,
     ) -> Result<(), SpError>;
+
+    fn versioned_rot_boot_info(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        version: u8,
+    ) -> Result<RotBootInfo, SpError>;
 }
 
 /// Handle a single incoming message.
@@ -991,6 +999,10 @@ fn handle_mgs_request<H: SpHandler>(
         MgsRequest::ComponentWatchdogSupported { component } => handler
             .component_watchdog_supported(component)
             .map(|()| SpResponse::ComponentWatchdogSupportedAck),
+        MgsRequest::VersionedRotBootInfo { version } => {
+            let r = handler.versioned_rot_boot_info(sender, port, version);
+            r.map(SpResponse::RotBootInfo)
+        }
     };
 
     let response = match result {
@@ -1414,6 +1426,15 @@ mod tests {
             &mut self,
             _component: SpComponent,
         ) -> Result<(), SpError> {
+            unimplemented!()
+        }
+
+        fn versioned_rot_boot_info(
+            &mut self,
+            _sender: SocketAddrV6,
+            _port: SpPort,
+            _version: u8,
+        ) -> Result<RotBootInfo, SpError> {
             unimplemented!()
         }
     }

--- a/gateway-messages/tests/versioning/mod.rs
+++ b/gateway-messages/tests/versioning/mod.rs
@@ -17,6 +17,7 @@ mod v09;
 mod v10;
 mod v11;
 mod v12;
+mod v13;
 
 pub fn assert_serialized(
     out: &mut [u8],

--- a/gateway-messages/tests/versioning/v13.rs
+++ b/gateway-messages/tests/versioning/v13.rs
@@ -1,0 +1,159 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! This source file is named after the protocol version being tested,
+//! e.g. v01.rs implements tests for protocol version 1.
+//! The tested protocol version is represented by "$VERSION" below.
+//!
+//! The tests in this module check that the serialized form of messages from MGS
+//! protocol version $VERSION have not changed.
+//!
+//! If a test in this module fails, _do not change the test_! This means you
+//! have changed, deleted, or reordered an existing message type or enum
+//! variant, and you should revert that change. This will remain true until we
+//! bump the `version::MIN` to a value higher than $VERSION, at which point these
+//! tests can be removed as we will stop supporting $VERSION.
+
+use super::assert_serialized;
+use gateway_messages::Fwid;
+use gateway_messages::ImageError;
+use gateway_messages::MgsRequest;
+use gateway_messages::RotBootInfo;
+use gateway_messages::RotSlotId;
+use gateway_messages::RotStateV3;
+use gateway_messages::SerializedSize;
+use gateway_messages::SpResponse;
+use gateway_messages::SpStateV3;
+use gateway_messages::UpdateError;
+
+#[test]
+fn sp_response() {
+    let mut out = [0; SpResponse::MAX_SIZE];
+    let response = SpResponse::SpStateV3(SpStateV3 {
+        hubris_archive_id: [1, 2, 3, 4, 5, 6, 7, 8],
+        serial_number: [
+            9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+            26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+        ],
+        model: [
+            41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+            58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72,
+        ],
+        revision: 0xf0f1f2f3,
+        base_mac_address: [73, 74, 75, 76, 77, 78],
+        power_state: gateway_messages::PowerState::A0,
+    });
+
+    #[rustfmt::skip]
+    let expected = vec![
+        44, // SpStateV3
+        1, 2, 3, 4, 5, 6, 7, 8, // hubris_archive_id
+
+        9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+        24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
+        39, 40, // serial_number
+
+        41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
+        56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
+        71, 72, // model
+
+        0xf3, 0xf2, 0xf1, 0xf0, // revision
+        73, 74, 75, 76, 77, 78, // base_mac_address
+        0, // power_state
+    ];
+
+    assert_serialized(&mut out, &expected, &response);
+}
+
+#[test]
+fn host_request() {
+    let mut out = [0; MgsRequest::MAX_SIZE];
+    let request = MgsRequest::VersionedRotBootInfo { version: 3 };
+
+    #[rustfmt::skip]
+    let expected = vec![
+        45, // VersionedRotBootInfo
+        3, // version
+    ];
+
+    assert_serialized(&mut out, &expected, &request);
+}
+
+#[test]
+fn rot_boot_info_v3() {
+    let mut out = [0; SpResponse::MAX_SIZE];
+
+    let response = SpResponse::RotBootInfo(RotBootInfo::V3(RotStateV3 {
+        active: RotSlotId::A,
+        persistent_boot_preference: RotSlotId::A,
+        pending_persistent_boot_preference: Some(RotSlotId::B),
+        transient_boot_preference: None,
+        slot_a_fwid: Fwid::Sha3_256([11u8; 32]),
+        slot_b_fwid: Fwid::Sha3_256([22u8; 32]),
+        stage0_fwid: Fwid::Sha3_256([33u8; 32]),
+        stage0next_fwid: Fwid::Sha3_256([44u8; 32]),
+        slot_a_status: Ok(()),
+        slot_b_status: Err(ImageError::Signature),
+        stage0_status: Ok(()),
+        stage0next_status: Err(ImageError::FirstPageErased),
+    }));
+
+    #[rustfmt::skip]
+    let expected =  vec![
+        45, 2, // SpResponse::RotBootInfo(RotBootInfo::V3(RotStateV3 {
+        0, // active: RotSlotId::A
+        0, // persistent_boot_preference: RotSlotId::A
+        1, 1, // pending_persistent_boot_preference: Some(RotSlotId::B)
+        0, // transient_boot_preference: None
+        0, // slot_a_fwid: Fwid::Sha3_256([11u8;32])
+        11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+        11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+        0, // slot_b_fwid: Fwid::Sha3_256([22u8;32])
+        22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22,
+        22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22,
+        0, // stage0_fwid: Fwid::Sha3_256([33u8;32])
+        33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33,
+        33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33,
+        0, // stage0next_fwid: Fwid::Sha3_256([44u8;32])
+        44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44,
+        44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44,
+        0, // slot_a_status: Ok(())
+        1, 12, // slot_b_status: Err(ImageError::Signature)
+        0, // stage0_status: Ok(())
+        1, 1 // stage0next_status: Err(ImageError::FirstPageErased)
+    ];
+
+    assert_serialized(&mut out, &expected, &response);
+}
+
+#[test]
+fn error_enums() {
+    let mut out = [0; SpResponse::MAX_SIZE];
+
+    let response: [ImageError; 13] = [
+        ImageError::Unchecked,
+        ImageError::FirstPageErased,
+        ImageError::PartiallyProgrammed,
+        ImageError::InvalidLength,
+        ImageError::HeaderNotProgrammed,
+        ImageError::BootloaderTooSmall,
+        ImageError::BadMagic,
+        ImageError::HeaderImageSize,
+        ImageError::UnalignedLength,
+        ImageError::UnsupportedType,
+        ImageError::ResetVectorNotThumb2,
+        ImageError::ResetVector,
+        ImageError::Signature,
+    ];
+    let expected = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+    assert_serialized(&mut out, &expected, &response);
+
+    let response: [UpdateError; 3] = [
+        UpdateError::BlockOutOfOrder,
+        UpdateError::InvalidComponent,
+        UpdateError::InvalidSlotIdForOperation,
+    ];
+    let expected = vec![27, 28, 29];
+    assert_serialized(&mut out, &expected, &response);
+}

--- a/gateway-sp-comms/src/error.rs
+++ b/gateway-sp-comms/src/error.rs
@@ -104,4 +104,12 @@ pub enum UpdateError {
     CorruptTlvc(String),
     #[error("failed to send update message to SP")]
     Communication(#[from] CommunicationError),
+    #[error("invalid zip archive")]
+    InvalidArchive,
+    #[error("invalid slot ID for operation")]
+    InvalidSlotIdForOperation,
+    #[error("invalid component for device")]
+    InvalidComponent,
+    #[error("an image was not found")]
+    ImageNotFound,
 }

--- a/gateway-sp-comms/src/lib.rs
+++ b/gateway-sp-comms/src/lib.rs
@@ -28,6 +28,7 @@ pub use gateway_messages;
 pub use gateway_messages::SpComponent;
 pub use gateway_messages::SpStateV1;
 pub use gateway_messages::SpStateV2;
+pub use gateway_messages::SpStateV3;
 pub use host_phase2::HostPhase2ImageError;
 pub use host_phase2::HostPhase2Provider;
 pub use host_phase2::InMemoryHostPhase2Provider;
@@ -70,4 +71,5 @@ pub struct SwitchPortConfig {
 pub enum VersionedSpState {
     V1(SpStateV1),
     V2(SpStateV2),
+    V3(SpStateV3),
 }

--- a/gateway-sp-comms/src/shared_socket.rs
+++ b/gateway-sp-comms/src/shared_socket.rs
@@ -430,6 +430,7 @@ enum RecvError {
 // we look up the `SingleSp` instance by the scope ID of the source of the
 // packet then send it an instance of this enum to handle.
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum SingleSpMessage {
     HostPhase2Request(HostPhase2Request),
     SerialConsole {

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -36,6 +36,7 @@ use gateway_messages::Message;
 use gateway_messages::MessageKind;
 use gateway_messages::MgsRequest;
 use gateway_messages::PowerState;
+use gateway_messages::RotBootInfo;
 use gateway_messages::RotRequest;
 use gateway_messages::SensorReading;
 use gateway_messages::SensorRequest;
@@ -391,6 +392,13 @@ impl SingleSp {
         self.rpc(MgsRequest::SpState).await.and_then(expect_sp_state)
     }
 
+    /// Request the state of the RoT.
+    pub async fn rot_state(&self, version: u8) -> Result<RotBootInfo> {
+        self.rpc(MgsRequest::VersionedRotBootInfo { version })
+            .await
+            .and_then(expect_rot_boot_info)
+    }
+
     /// Request the inventory of the SP.
     pub async fn inventory(&self) -> Result<SpInventory> {
         let devices = self.get_paginated_tlv_data(InventoryTlvRpc).await?;
@@ -592,9 +600,16 @@ impl SingleSp {
                 ));
             }
             start_sp_update(&self.cmds_tx, update_id, image, self.log()).await
-        } else if component == SpComponent::ROT {
-            start_rot_update(&self.cmds_tx, update_id, slot, image, self.log())
-                .await
+        } else if matches!(component, SpComponent::ROT | SpComponent::STAGE0) {
+            start_rot_update(
+                &self.cmds_tx,
+                update_id,
+                component,
+                slot,
+                image,
+                self.log(),
+            )
+            .await
         } else {
             start_component_update(
                 &self.cmds_tx,


### PR DESCRIPTION
Support update of RoT bootloader.

Includes always calculating FWID and signature check at RoT boot time.
Messages for SP and RoT Hubris updates are backward compatible.

See https://github.com/oxidecomputer/sprot-e2e for test scripts that exercise update and rollback of Hubris and Bootleby on SP and RoT.

A new RoTBootInfo mesage is plumbed that includes info on the four RoT flash banks.

The ImageError enum gives detailed information on invalid RoT flash bank contents.

This is a draft PR because it needs to be coordinated with hubris and omicron changes so as not to break people's development environments.

Closes #208