### PR TITLE
Add tech port unlocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +247,16 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clap"
@@ -360,6 +376,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +431,7 @@ dependencies = [
  "block-buffer",
  "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -449,6 +478,38 @@ dependencies = [
  "pest",
  "pest_derive",
  "thiserror",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a48e5d537b8a30c0b023116d981b16334be1485af7ca68db3a2b7024cbc957fd"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -502,11 +563,22 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-term",
+ "ssh-key",
  "termios",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "uuid",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -685,6 +757,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -719,6 +792,17 @@ dependencies = [
  "log",
  "plain",
  "scroll",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -792,6 +876,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "hubpack"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +933,15 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1169,6 +1271,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core",
+ "sha2",
+]
+
+[[package]]
 name = "packed_struct"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1492,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc83ee4a840062f368f9096d80077a9841ec117e17e7f700df81958f1451254"
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,6 +1596,16 @@ dependencies = [
  "getrandom",
  "redox_syscall",
  "thiserror",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -1561,6 +1720,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1818,6 +1991,47 @@ checksum = "37a5be806ab6f127c3da44b7378837ebf01dadca8510a0e572460216b228bd0e"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "cipher",
+ "ssh-encoding",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "pem-rfc7468",
+ "sha2",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca9b366a80cf18bb6406f4cf4d10aebfb46140a8c0c33f666a144c5c76ecbafc"
+dependencies = [
+ "p256",
+ "p384",
+ "p521",
+ "rand_core",
+ "rsa",
+ "sec1",
+ "sha2",
+ "signature",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,7 @@ dependencies = [
  "bitflags 2.6.0",
  "hubpack",
  "serde",
+ "serde-big-array",
  "serde_json",
  "serde_repr",
  "smoltcp",
@@ -678,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -2510,9 +2511,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ slog-async = "2.8"
 slog-term = "2.9"
 smoltcp = { version = "0.9", default-features = false, features = ["proto-ipv6"] }
 socket2 = "0.5.7"
+ssh-key = { version = "0.6.6", features = ["p256"] }
 static_assertions = "1.1.0"
 strum_macros = "0.25"
 string_cache = "0.8.7"

--- a/faux-mgs/Cargo.toml
+++ b/faux-mgs/Cargo.toml
@@ -18,6 +18,7 @@ sha2.workspace = true
 slog.workspace = true
 slog-async.workspace = true
 slog-term.workspace = true
+ssh-key.workspace = true
 termios.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true

--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -38,6 +38,7 @@ use gateway_sp_comms::SwitchPortConfig;
 use gateway_sp_comms::VersionedSpState;
 use gateway_sp_comms::MGS_PORT;
 use serde_json::json;
+use slog::debug;
 use slog::info;
 use slog::o;
 use slog::warn;
@@ -421,6 +422,10 @@ enum MonorailCommand {
     Unlock {
         /// How long to unlock for
         time_sec: u32,
+
+        /// Path to private key for SSH signing challenge
+        #[clap(long)]
+        key: Option<PathBuf>,
     },
 
     /// Lock the technician port
@@ -1318,8 +1323,8 @@ async fn run_command(
                     )
                     .await?
                 }
-                MonorailCommand::Unlock { time_sec } => {
-                    monorail_unlock(&log, &sp, time_sec).await?;
+                MonorailCommand::Unlock { time_sec, key } => {
+                    monorail_unlock(&log, &sp, time_sec, key).await?;
                 }
             }
             if json {
@@ -1435,6 +1440,7 @@ async fn monorail_unlock(
     log: &Logger,
     sp: &SingleSp,
     time_sec: u32,
+    key: Option<PathBuf>,
 ) -> Result<()> {
     let r = sp
         .component_action_with_response(
@@ -1455,6 +1461,58 @@ async fn monorail_unlock(
 
     let response = match challenge {
         UnlockChallenge::Trivial => UnlockResponse::Trivial,
+        UnlockChallenge::EcdsaSha2Nistp256(data) => {
+            let Some(priv_path) = key else {
+                bail!("need --key for ECDSA challenge");
+            };
+
+            debug!(log, "loading private key from {priv_path:?}");
+            let priv_key = ssh_key::PrivateKey::read_openssh_file(&priv_path)
+                .with_context(|| {
+                "failed to read private key at {priv_path}"
+            })?;
+            if priv_key.algorithm()
+                != (ssh_key::Algorithm::Ecdsa {
+                    curve: ssh_key::EcdsaCurve::NistP256,
+                })
+            {
+                bail!("invalid algorithm {:?}", priv_key.algorithm());
+            }
+
+            let signed = priv_key.sign(
+                "monorail-unlock",
+                ssh_key::HashAlg::Sha256,
+                &data,
+            )?;
+            debug!(log, "got signature {signed:?}");
+
+            let key_bytes =
+                signed.public_key().ecdsa().unwrap().as_sec1_bytes();
+            assert_eq!(key_bytes.len(), 65, "invalid key length");
+            let mut key = [0u8; 65];
+            key.copy_from_slice(key_bytes);
+
+            // Signature bytes are encoded per
+            // https://datatracker.ietf.org/doc/html/rfc5656#section-3.1.2
+            //
+            // They are a pair of `mpint` values, per
+            // https://datatracker.ietf.org/doc/html/rfc4251
+            //
+            // Each one is either 32 bytes or 33 bytes with a leading zero, so
+            // we'll awkwardly allow for both cases.
+            let sig_bytes = signed.signature_bytes();
+            let mut signature = [0u8; 64];
+            let start = match sig_bytes[3] {
+                32 => 4,
+                33 => 5,
+                i => bail!("invalid length {i}"),
+            };
+            signature[0..32].copy_from_slice(&sig_bytes[start..][..32]);
+            let tail = sig_bytes.len() - 32;
+            signature[32..64].copy_from_slice(&sig_bytes[tail..][..32]);
+
+            UnlockResponse::EcdsaSha2Nistp256 { key, signature }
+        }
     };
     sp.component_action(
         SpComponent::MONORAIL,

--- a/gateway-messages/Cargo.toml
+++ b/gateway-messages/Cargo.toml
@@ -8,6 +8,7 @@ license = "MPL-2.0"
 bitflags.workspace = true
 hubpack.workspace = true
 serde.workspace = true
+serde-big-array.workspace = true
 serde_repr.workspace = true
 smoltcp = { workspace = true, optional = true }
 static_assertions.workspace = true

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -66,7 +66,7 @@ pub const ROT_PAGE_SIZE: usize = 512;
 /// for more detail and discussion.
 pub mod version {
     pub const MIN: u32 = 2;
-    pub const CURRENT: u32 = 14;
+    pub const CURRENT: u32 = 15;
 
     /// MGS protocol version in which SP watchdog messages were added
     pub const WATCHDOG_VERSION: u32 = 12;

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -66,7 +66,7 @@ pub const ROT_PAGE_SIZE: usize = 512;
 /// for more detail and discussion.
 pub mod version {
     pub const MIN: u32 = 2;
-    pub const CURRENT: u32 = 13;
+    pub const CURRENT: u32 = 14;
 
     /// MGS protocol version in which SP watchdog messages were added
     pub const WATCHDOG_VERSION: u32 = 12;

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -16,6 +16,7 @@ use crate::UpdateId;
 use hubpack::SerializedSize;
 use serde::Deserialize;
 use serde::Serialize;
+use serde_big_array::BigArray;
 
 #[derive(
     Debug, Clone, Copy, SerializedSize, Serialize, Deserialize, PartialEq, Eq,
@@ -320,8 +321,10 @@ pub enum MonorailComponentAction {
     Copy, Clone, Serialize, SerializedSize, Deserialize, PartialEq, Eq, Debug,
 )]
 pub enum UnlockChallenge {
-    /// Unlock given an [UnlockResponse::Trivial]
+    /// Return [UnlockResponse::Trivial]
     Trivial,
+    /// Hash and sign the given data with a key that the SP trusts
+    EcdsaSha2Nistp256([u8; 32]),
 }
 
 /// Actions for the Monorail switch
@@ -329,7 +332,19 @@ pub enum UnlockChallenge {
     Copy, Clone, Serialize, SerializedSize, Deserialize, PartialEq, Eq, Debug,
 )]
 pub enum UnlockResponse {
+    /// Unlocks [UnlockChallenge::Trivial]
     Trivial,
+
+    /// Here's your signature!
+    EcdsaSha2Nistp256 {
+        /// SEC1 encoding of the corresponding public key
+        #[serde(with = "BigArray")]
+        key: [u8; 65],
+
+        /// Signature data, as an (x, y) tuple (32 bytes each)
+        #[serde(with = "BigArray")]
+        signature: [u8; 64],
+    },
 }
 
 #[derive(

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -280,6 +280,7 @@ pub struct ComponentUpdatePrepare {
 )]
 pub enum ComponentAction {
     Led(LedComponentAction),
+    Monorail(MonorailComponentAction),
 }
 
 /// Actions for LED components, i.e. components with `IS_LED` set
@@ -290,6 +291,45 @@ pub enum LedComponentAction {
     TurnOn,
     TurnOff,
     Blink,
+}
+
+/// Actions for the Monorail switch
+#[derive(
+    Copy, Clone, Serialize, SerializedSize, Deserialize, PartialEq, Eq, Debug,
+)]
+pub enum MonorailComponentAction {
+    /// Request an `UnlockChallenge`
+    ///
+    /// The SP will reply with the weakest challenge that it will accept, and
+    /// will store that challenge locally (to prevent replay attacks)
+    RequestChallenge,
+
+    /// Unlock the management network, allowing access from the tech port
+    Unlock {
+        challenge: UnlockChallenge,
+        response: UnlockResponse,
+        time_sec: u32,
+    },
+
+    /// Relock the management network
+    Lock,
+}
+
+/// Actions for the Monorail switch
+#[derive(
+    Copy, Clone, Serialize, SerializedSize, Deserialize, PartialEq, Eq, Debug,
+)]
+pub enum UnlockChallenge {
+    /// Unlock given an [UnlockResponse::Trivial]
+    Trivial,
+}
+
+/// Actions for the Monorail switch
+#[derive(
+    Copy, Clone, Serialize, SerializedSize, Deserialize, PartialEq, Eq, Debug,
+)]
+pub enum UnlockResponse {
+    Trivial,
 }
 
 #[derive(

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -10,6 +10,7 @@ use crate::tlv;
 use crate::version;
 use crate::BadRequestReason;
 use crate::ComponentAction;
+use crate::ComponentActionResponse;
 use crate::ComponentDetails;
 use crate::ComponentUpdatePrepare;
 use crate::DeviceCapabilities;
@@ -85,123 +86,108 @@ impl From<DeviceDescription<'_>> for DeviceDescriptionHeader {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BoundsChecked(pub u32);
 
+/// Helper type to identify the sender of a message
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct Sender {
+    /// Address of the sender
+    pub addr: SocketAddrV6,
+    /// SP port on which the packet was received
+    pub port: SpPort,
+    /// VLAN tag associated with the received packet
+    ///
+    /// This is often one-to-one equivalent to `port`; however, on Sidecar,
+    /// multiple VLANs are mapped to `SpPort::One`.
+    pub vid: u16,
+}
+
 pub trait SpHandler {
     type BulkIgnitionStateIter: Iterator<Item = IgnitionState>;
     type BulkIgnitionLinkEventsIter: Iterator<Item = LinkEvents>;
 
-    fn discover(
+    /// Checks whether we will answer messages from the given sender
+    ///
+    /// This may vary depending on message type and whether the sender's VID is
+    /// trusted.
+    fn is_message_trusted(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
-    ) -> Result<DiscoverResponse, SpError>;
+        kind: &MgsRequest,
+        sender: Sender,
+    ) -> Result<(), SpError>;
+
+    fn discover(&mut self, sender: Sender)
+        -> Result<DiscoverResponse, SpError>;
 
     fn num_ignition_ports(&mut self) -> Result<u32, SpError>;
-
-    fn ignition_state(
-        &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
-        target: u8,
-    ) -> Result<IgnitionState, SpError>;
+    fn ignition_state(&mut self, target: u8) -> Result<IgnitionState, SpError>;
 
     fn bulk_ignition_state(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
         offset: u32,
     ) -> Result<Self::BulkIgnitionStateIter, SpError>;
 
     fn ignition_link_events(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
         target: u8,
     ) -> Result<LinkEvents, SpError>;
 
     fn bulk_ignition_link_events(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
         offset: u32,
     ) -> Result<Self::BulkIgnitionLinkEventsIter, SpError>;
 
     /// If `target` is `None`, clear link events for all targets.
     fn clear_ignition_link_events(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
         target: Option<u8>,
         transceiver_select: Option<ignition::TransceiverSelect>,
     ) -> Result<(), SpError>;
 
     fn ignition_command(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
         target: u8,
         command: IgnitionCommand,
     ) -> Result<(), SpError>;
 
-    fn sp_state(
-        &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
-    ) -> Result<SpStateV2, SpError>;
+    fn sp_state(&mut self) -> Result<SpStateV2, SpError>;
 
     fn sp_update_prepare(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
         update: SpUpdatePrepare,
     ) -> Result<(), SpError>;
 
     fn component_update_prepare(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
         update: ComponentUpdatePrepare,
     ) -> Result<(), SpError>;
 
     fn update_chunk(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
         chunk: UpdateChunk,
         data: &[u8],
     ) -> Result<(), SpError>;
 
     fn update_status(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
         component: SpComponent,
     ) -> Result<UpdateStatus, SpError>;
 
     fn update_abort(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
         component: SpComponent,
         id: UpdateId,
     ) -> Result<(), SpError>;
 
-    fn power_state(
-        &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
-    ) -> Result<PowerState, SpError>;
+    fn power_state(&mut self) -> Result<PowerState, SpError>;
 
     fn set_power_state(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
+        sender: Sender,
         power_state: PowerState,
     ) -> Result<(), SpError>;
 
     fn serial_console_attach(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
+        sender: Sender,
         component: SpComponent,
     ) -> Result<(), SpError>;
 
@@ -210,32 +196,22 @@ pub trait SpHandler {
     /// ingested (either by writing to the console or by buffering to write it).
     fn serial_console_write(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
+        sender: Sender,
         offset: u64,
         data: &[u8],
     ) -> Result<u64, SpError>;
 
-    fn serial_console_detach(
-        &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
-    ) -> Result<(), SpError>;
+    fn serial_console_detach(&mut self, sender: Sender) -> Result<(), SpError>;
 
     fn serial_console_keepalive(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
+        sender: Sender,
     ) -> Result<(), SpError>;
 
-    fn serial_console_break(
-        &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
-    ) -> Result<(), SpError>;
+    fn serial_console_break(&mut self, sender: Sender) -> Result<(), SpError>;
 
     /// Number of devices returned in the inventory of this SP.
-    fn num_devices(&mut self, sender: SocketAddrV6, port: SpPort) -> u32;
+    fn num_devices(&mut self) -> u32;
 
     /// Get the description for the given device.
     ///
@@ -259,8 +235,6 @@ pub trait SpHandler {
     /// component.
     fn num_component_details(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
         component: SpComponent,
     ) -> Result<u32, SpError>;
 
@@ -283,22 +257,16 @@ pub trait SpHandler {
 
     fn component_clear_status(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
         component: SpComponent,
     ) -> Result<(), SpError>;
 
     fn component_get_active_slot(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
         component: SpComponent,
     ) -> Result<u16, SpError>;
 
     fn component_set_active_slot(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
         component: SpComponent,
         slot: u16,
         persist: bool,
@@ -306,52 +274,33 @@ pub trait SpHandler {
 
     fn component_action(
         &mut self,
-        sender: SocketAddrV6,
+        sender: Sender,
         component: SpComponent,
         action: ComponentAction,
-    ) -> Result<(), SpError>;
+    ) -> Result<ComponentActionResponse, SpError>;
 
-    fn get_startup_options(
-        &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
-    ) -> Result<StartupOptions, SpError>;
+    fn get_startup_options(&mut self) -> Result<StartupOptions, SpError>;
 
     fn set_startup_options(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
         startup_options: StartupOptions,
     ) -> Result<(), SpError>;
 
-    fn mgs_response_error(
-        &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
-        message_id: u32,
-        err: MgsError,
-    );
+    fn mgs_response_error(&mut self, message_id: u32, err: MgsError);
 
     fn mgs_response_host_phase2_data(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
+        sender: Sender,
         message_id: u32,
         hash: [u8; 32],
         offset: u64,
         data: &[u8],
     );
 
-    fn send_host_nmi(
-        &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
-    ) -> Result<(), SpError>;
+    fn send_host_nmi(&mut self) -> Result<(), SpError>;
 
     fn set_ipcc_key_lookup_value(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
         key: u8,
         value: &[u8],
     ) -> Result<(), SpError>;
@@ -366,8 +315,6 @@ pub trait SpHandler {
 
     fn reset_component_prepare(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
         component: SpComponent,
     ) -> Result<(), SpError>;
 
@@ -375,8 +322,6 @@ pub trait SpHandler {
     // affects the SP_ITSELF.
     fn reset_component_trigger(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
         component: SpComponent,
     ) -> Result<(), SpError>;
 
@@ -416,8 +361,6 @@ pub trait SpHandler {
 
     fn versioned_rot_boot_info(
         &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
         version: u8,
     ) -> Result<RotBootInfo, SpError>;
 }
@@ -434,8 +377,7 @@ pub trait SpHandler {
 /// message does not warrant a response, `out` remains unchanged and `None` is
 /// returned.
 pub fn handle_message<H: SpHandler>(
-    sender: SocketAddrV6,
-    port: SpPort,
+    sender: Sender,
     data: &[u8],
     handler: &mut H,
     out: &mut [u8; crate::MAX_SERIALIZED_SIZE],
@@ -447,7 +389,6 @@ pub fn handle_message<H: SpHandler>(
             ReadHeaderResult::Ok { header, remaining_data } => {
                 let (response, outgoing_trailing_data) = handle_message_impl(
                     sender,
-                    port,
                     header,
                     remaining_data,
                     handler,
@@ -636,8 +577,7 @@ fn read_request_header(data: &[u8]) -> ReadHeaderResult<'_> {
 /// and our caller is responsible for handling that generation. Otherwise,
 /// returns `(_, None)`.
 fn handle_message_impl<H: SpHandler>(
-    sender: SocketAddrV6,
-    port: SpPort,
+    sender: Sender,
     header: Header,
     request_kind_data: &[u8],
     handler: &mut H,
@@ -647,7 +587,6 @@ fn handle_message_impl<H: SpHandler>(
         Ok((MessageKind::MgsRequest(kind), leftover)) => {
             Some(handle_mgs_request(
                 sender,
-                port,
                 handler,
                 kind,
                 leftover,
@@ -657,7 +596,6 @@ fn handle_message_impl<H: SpHandler>(
         Ok((MessageKind::MgsResponse(kind), leftover)) => {
             handle_mgs_response(
                 sender,
-                port,
                 header.message_id,
                 handler,
                 kind,
@@ -697,27 +635,24 @@ fn handle_message_impl<H: SpHandler>(
 }
 
 fn handle_mgs_response<H: SpHandler>(
-    sender: SocketAddrV6,
-    port: SpPort,
+    sender: Sender,
     message_id: u32,
     handler: &mut H,
     kind: MgsResponse,
     leftover: &[u8],
 ) {
+    // TODO check sender here?
     match kind {
-        MgsResponse::Error(err) => {
-            handler.mgs_response_error(sender, port, message_id, err)
-        }
+        MgsResponse::Error(err) => handler.mgs_response_error(message_id, err),
         MgsResponse::HostPhase2Data { hash, offset } => handler
             .mgs_response_host_phase2_data(
-                sender, port, message_id, hash, offset, leftover,
+                sender, message_id, hash, offset, leftover,
             ),
     }
 }
 
 fn handle_mgs_request<H: SpHandler>(
-    sender: SocketAddrV6,
-    port: SpPort,
+    sender: Sender,
     handler: &mut H,
     kind: MgsRequest,
     leftover: &[u8],
@@ -743,6 +678,13 @@ fn handle_mgs_request<H: SpHandler>(
         }
     };
 
+    // Check whether this message is trusted, bailing out early if that's not
+    // the case.  The logic of message trust is implemented by the SpHandler,
+    // and will typically check message type and sender VLAN.
+    if let Err(e) = handler.is_message_trusted(&kind, sender) {
+        return (SpResponse::Error(e), None);
+    }
+
     // Call out to handler to provide response.
     //
     // The vast majority of response kinds do not need to pack additional
@@ -753,15 +695,15 @@ fn handle_mgs_request<H: SpHandler>(
     let mut outgoing_trailing_data = None;
     let result = match kind {
         MgsRequest::Discover => {
-            handler.discover(sender, port).map(SpResponse::Discover)
+            handler.discover(sender).map(SpResponse::Discover)
         }
-        MgsRequest::IgnitionState { target } => handler
-            .ignition_state(sender, port, target)
-            .map(SpResponse::IgnitionState),
+        MgsRequest::IgnitionState { target } => {
+            handler.ignition_state(target).map(SpResponse::IgnitionState)
+        }
         MgsRequest::BulkIgnitionState { offset } => {
             handler.num_ignition_ports().and_then(|port_count| {
                 let offset = u32::min(offset, port_count);
-                let iter = handler.bulk_ignition_state(sender, port, offset)?;
+                let iter = handler.bulk_ignition_state(offset)?;
                 outgoing_trailing_data =
                     Some(OutgoingTrailingData::BulkIgnitionState(iter));
                 Ok(SpResponse::BulkIgnitionState(TlvPage {
@@ -771,13 +713,12 @@ fn handle_mgs_request<H: SpHandler>(
             })
         }
         MgsRequest::IgnitionLinkEvents { target } => handler
-            .ignition_link_events(sender, port, target)
+            .ignition_link_events(target)
             .map(SpResponse::IgnitionLinkEvents),
         MgsRequest::BulkIgnitionLinkEvents { offset } => {
             handler.num_ignition_ports().and_then(|port_count| {
                 let offset = u32::min(offset, port_count);
-                let iter =
-                    handler.bulk_ignition_link_events(sender, port, offset)?;
+                let iter = handler.bulk_ignition_link_events(offset)?;
                 outgoing_trailing_data =
                     Some(OutgoingTrailingData::BulkIgnitionLinkEvents(iter));
                 Ok(SpResponse::BulkIgnitionLinkEvents(TlvPage {
@@ -788,66 +729,59 @@ fn handle_mgs_request<H: SpHandler>(
         }
         MgsRequest::ClearIgnitionLinkEvents { target, transceiver_select } => {
             handler
-                .clear_ignition_link_events(
-                    sender,
-                    port,
-                    target,
-                    transceiver_select,
-                )
+                .clear_ignition_link_events(target, transceiver_select)
                 .map(|()| SpResponse::ClearIgnitionLinkEventsAck)
         }
         MgsRequest::IgnitionCommand { target, command } => handler
-            .ignition_command(sender, port, target, command)
+            .ignition_command(target, command)
             .map(|()| SpResponse::IgnitionCommandAck),
-        MgsRequest::SpState => {
-            handler.sp_state(sender, port).map(SpResponse::SpStateV2)
-        }
+        MgsRequest::SpState => handler.sp_state().map(SpResponse::SpStateV2),
         MgsRequest::SpUpdatePrepare(update) => handler
-            .sp_update_prepare(sender, port, update)
+            .sp_update_prepare(update)
             .map(|()| SpResponse::SpUpdatePrepareAck),
         MgsRequest::ComponentUpdatePrepare(update) => handler
-            .component_update_prepare(sender, port, update)
+            .component_update_prepare(update)
             .map(|()| SpResponse::ComponentUpdatePrepareAck),
         MgsRequest::UpdateChunk(chunk) => handler
-            .update_chunk(sender, port, chunk, trailing_data)
+            .update_chunk(chunk, trailing_data)
             .map(|()| SpResponse::UpdateChunkAck),
-        MgsRequest::UpdateStatus(component) => handler
-            .update_status(sender, port, component)
-            .map(SpResponse::UpdateStatus),
+        MgsRequest::UpdateStatus(component) => {
+            handler.update_status(component).map(SpResponse::UpdateStatus)
+        }
         MgsRequest::UpdateAbort { component, id } => handler
-            .update_abort(sender, port, component, id)
+            .update_abort(component, id)
             .map(|()| SpResponse::UpdateAbortAck),
         MgsRequest::SerialConsoleAttach(component) => handler
-            .serial_console_attach(sender, port, component)
+            .serial_console_attach(sender, component)
             .map(|()| SpResponse::SerialConsoleAttachAck),
         MgsRequest::SerialConsoleWrite { offset } => handler
-            .serial_console_write(sender, port, offset, trailing_data)
+            .serial_console_write(sender, offset, trailing_data)
             .map(|n| SpResponse::SerialConsoleWriteAck {
                 furthest_ingested_offset: n,
             }),
         MgsRequest::SerialConsoleDetach => handler
-            .serial_console_detach(sender, port)
+            .serial_console_detach(sender)
             .map(|()| SpResponse::SerialConsoleDetachAck),
         MgsRequest::SerialConsoleKeepAlive => handler
-            .serial_console_keepalive(sender, port)
+            .serial_console_keepalive(sender)
             .map(|()| SpResponse::SerialConsoleKeepAliveAck),
         MgsRequest::SerialConsoleBreak => handler
-            .serial_console_break(sender, port)
+            .serial_console_break(sender)
             .map(|()| SpResponse::SerialConsoleBreakAck),
         MgsRequest::GetPowerState => {
-            handler.power_state(sender, port).map(SpResponse::PowerState)
+            handler.power_state().map(SpResponse::PowerState)
         }
         MgsRequest::SetPowerState(power_state) => handler
-            .set_power_state(sender, port, power_state)
+            .set_power_state(sender, power_state)
             .map(|()| SpResponse::SetPowerStateAck),
         MgsRequest::ResetPrepare => handler
-            .reset_component_prepare(sender, port, SpComponent::SP_ITSELF)
+            .reset_component_prepare(SpComponent::SP_ITSELF)
             .map(|()| SpResponse::ResetPrepareAck),
         MgsRequest::ResetTrigger => handler
-            .reset_component_trigger(sender, port, SpComponent::SP_ITSELF)
+            .reset_component_trigger(SpComponent::SP_ITSELF)
             .map(|()| SpResponse::ResetComponentTriggerAck),
         MgsRequest::Inventory { device_index } => {
-            let total_devices = handler.num_devices(sender, port);
+            let total_devices = handler.num_devices();
             // If a caller asks for an index past our end, clamp it.
             let device_index = u32::min(device_index, total_devices);
             // We need to pack TLV-encoded device descriptions as our outgoing
@@ -862,15 +796,14 @@ fn handle_mgs_request<H: SpHandler>(
                 total: total_devices,
             }))
         }
-        MgsRequest::GetStartupOptions => handler
-            .get_startup_options(sender, port)
-            .map(SpResponse::StartupOptions),
+        MgsRequest::GetStartupOptions => {
+            handler.get_startup_options().map(SpResponse::StartupOptions)
+        }
         MgsRequest::SetStartupOptions(startup_options) => handler
-            .set_startup_options(sender, port, startup_options)
+            .set_startup_options(startup_options)
             .map(|()| SpResponse::SetStartupOptionsAck),
-        MgsRequest::ComponentDetails { component, offset } => handler
-            .num_component_details(sender, port, component)
-            .map(|total_items| {
+        MgsRequest::ComponentDetails { component, offset } => {
+            handler.num_component_details(component).map(|total_items| {
                 // If a caller asks for an index past our end, clamp it.
                 let offset = u32::min(offset, total_items);
                 // We need to pack TLV-encoded component details as our
@@ -885,29 +818,30 @@ fn handle_mgs_request<H: SpHandler>(
                     offset,
                     total: total_items,
                 })
-            }),
+            })
+        }
         MgsRequest::ComponentClearStatus(component) => handler
-            .component_clear_status(sender, port, component)
+            .component_clear_status(component)
             .map(|()| SpResponse::ComponentClearStatusAck),
         MgsRequest::ComponentGetActiveSlot(component) => handler
-            .component_get_active_slot(sender, port, component)
+            .component_get_active_slot(component)
             .map(SpResponse::ComponentActiveSlot),
         MgsRequest::ComponentSetActiveSlot { component, slot } => handler
-            .component_set_active_slot(sender, port, component, slot, false)
+            .component_set_active_slot(component, slot, false)
             .map(|()| SpResponse::ComponentSetActiveSlotAck),
         MgsRequest::ComponentSetAndPersistActiveSlot { component, slot } => {
             handler
-                .component_set_active_slot(sender, port, component, slot, true)
+                .component_set_active_slot(component, slot, true)
                 .map(|()| SpResponse::ComponentSetAndPersistActiveSlotAck)
         }
-        MgsRequest::SendHostNmi => handler
-            .send_host_nmi(sender, port)
-            .map(|()| SpResponse::SendHostNmiAck),
+        MgsRequest::SendHostNmi => {
+            handler.send_host_nmi().map(|()| SpResponse::SendHostNmiAck)
+        }
         MgsRequest::SetIpccKeyLookupValue { key } => handler
-            .set_ipcc_key_lookup_value(sender, port, key, trailing_data)
+            .set_ipcc_key_lookup_value(key, trailing_data)
             .map(|()| SpResponse::SetIpccKeyLookupValueAck),
         MgsRequest::ResetComponentPrepare { component } => handler
-            .reset_component_prepare(sender, port, component)
+            .reset_component_prepare(component)
             .map(|()| SpResponse::ResetComponentPrepareAck),
         MgsRequest::ResetComponentTrigger { component } => {
             // Until further implementations are done, only the RoT
@@ -919,7 +853,7 @@ fn handle_mgs_request<H: SpHandler>(
             // In a case where the SP is reset, not some sub-component, there
             // would be no response.
             handler
-                .reset_component_trigger(sender, port, component)
+                .reset_component_trigger(component)
                 .map(|()| SpResponse::ResetComponentTriggerAck)
         }
         MgsRequest::SwitchDefaultImage { component, slot, duration } => {
@@ -932,14 +866,15 @@ fn handle_mgs_request<H: SpHandler>(
                 SwitchDuration::Forever => true,
             };
             handler
-                .component_set_active_slot(
-                    sender, port, component, slot, persist,
-                )
+                .component_set_active_slot(component, slot, persist)
                 .map(|()| SpResponse::SwitchDefaultImageAck)
         }
         MgsRequest::ComponentAction { component, action } => handler
             .component_action(sender, component, action)
-            .map(|()| SpResponse::ComponentActionAck),
+            .map(|a| match a {
+                ComponentActionResponse::Ack => SpResponse::ComponentActionAck,
+                r => SpResponse::ComponentAction(r),
+            }),
         MgsRequest::ReadCaboose { key }
         | MgsRequest::ReadComponentCaboose { key, .. } => {
             let (component, slot) = if let MgsRequest::ReadComponentCaboose {
@@ -1000,7 +935,7 @@ fn handle_mgs_request<H: SpHandler>(
             .component_watchdog_supported(component)
             .map(|()| SpResponse::ComponentWatchdogSupportedAck),
         MgsRequest::VersionedRotBootInfo { version } => {
-            let r = handler.versioned_rot_boot_info(sender, port, version);
+            let r = handler.versioned_rot_boot_info(version);
             r.map(SpResponse::RotBootInfo)
         }
     };
@@ -1048,12 +983,20 @@ mod tests {
         type BulkIgnitionStateIter = std::iter::Empty<IgnitionState>;
         type BulkIgnitionLinkEventsIter = std::iter::Empty<LinkEvents>;
 
+        fn is_message_trusted(
+            &mut self,
+            _kind: &MgsRequest,
+            _sender: Sender,
+        ) -> Result<(), SpError> {
+            // Trust everyone!
+            Ok(())
+        }
+
         fn discover(
             &mut self,
-            _sender: SocketAddrV6,
-            port: SpPort,
+            sender: Sender,
         ) -> Result<DiscoverResponse, SpError> {
-            Ok(DiscoverResponse { sp_port: port })
+            Ok(DiscoverResponse { sp_port: sender.port })
         }
 
         fn num_ignition_ports(&mut self) -> Result<u32, SpError> {
@@ -1062,8 +1005,6 @@ mod tests {
 
         fn ignition_state(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
             _target: u8,
         ) -> Result<IgnitionState, SpError> {
             unimplemented!()
@@ -1071,8 +1012,6 @@ mod tests {
 
         fn bulk_ignition_state(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
             _offset: u32,
         ) -> Result<Self::BulkIgnitionStateIter, SpError> {
             unimplemented!()
@@ -1080,8 +1019,6 @@ mod tests {
 
         fn bulk_ignition_link_events(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
             _offset: u32,
         ) -> Result<Self::BulkIgnitionLinkEventsIter, SpError> {
             unimplemented!()
@@ -1089,8 +1026,6 @@ mod tests {
 
         fn ignition_link_events(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
             _target: u8,
         ) -> Result<LinkEvents, SpError> {
             unimplemented!()
@@ -1098,8 +1033,6 @@ mod tests {
 
         fn clear_ignition_link_events(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
             _target: Option<u8>,
             _transceiver_select: Option<ignition::TransceiverSelect>,
         ) -> Result<(), SpError> {
@@ -1108,26 +1041,18 @@ mod tests {
 
         fn ignition_command(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
             _target: u8,
             _command: IgnitionCommand,
         ) -> Result<(), SpError> {
             unimplemented!()
         }
 
-        fn sp_state(
-            &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
-        ) -> Result<SpStateV2, SpError> {
+        fn sp_state(&mut self) -> Result<SpStateV2, SpError> {
             unimplemented!()
         }
 
         fn sp_update_prepare(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
             _update: SpUpdatePrepare,
         ) -> Result<(), SpError> {
             unimplemented!()
@@ -1135,8 +1060,6 @@ mod tests {
 
         fn component_update_prepare(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
             _update: ComponentUpdatePrepare,
         ) -> Result<(), SpError> {
             unimplemented!()
@@ -1144,8 +1067,6 @@ mod tests {
 
         fn update_chunk(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
             _chunk: UpdateChunk,
             _data: &[u8],
         ) -> Result<(), SpError> {
@@ -1154,8 +1075,6 @@ mod tests {
 
         fn update_status(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
             _component: SpComponent,
         ) -> Result<UpdateStatus, SpError> {
             unimplemented!()
@@ -1163,26 +1082,19 @@ mod tests {
 
         fn update_abort(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
             _component: SpComponent,
             _id: UpdateId,
         ) -> Result<(), SpError> {
             unimplemented!()
         }
 
-        fn power_state(
-            &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
-        ) -> Result<PowerState, SpError> {
+        fn power_state(&mut self) -> Result<PowerState, SpError> {
             unimplemented!()
         }
 
         fn set_power_state(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
+            _sender: Sender,
             _power_state: PowerState,
         ) -> Result<(), SpError> {
             unimplemented!()
@@ -1190,8 +1102,7 @@ mod tests {
 
         fn serial_console_attach(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
+            _sender: Sender,
             _component: SpComponent,
         ) -> Result<(), SpError> {
             unimplemented!()
@@ -1199,8 +1110,7 @@ mod tests {
 
         fn serial_console_write(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
+            _sender: Sender,
             _offset: u64,
             _data: &[u8],
         ) -> Result<u64, SpError> {
@@ -1209,29 +1119,26 @@ mod tests {
 
         fn serial_console_detach(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
+            _sender: Sender,
         ) -> Result<(), SpError> {
             unimplemented!()
         }
 
         fn serial_console_keepalive(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
+            _sender: Sender,
         ) -> Result<(), SpError> {
             unimplemented!()
         }
 
         fn serial_console_break(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
+            _sender: Sender,
         ) -> Result<(), SpError> {
             unimplemented!()
         }
 
-        fn num_devices(&mut self, _sender: SocketAddrV6, _port: SpPort) -> u32 {
+        fn num_devices(&mut self) -> u32 {
             unimplemented!()
         }
 
@@ -1244,8 +1151,6 @@ mod tests {
 
         fn num_component_details(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
             _component: SpComponent,
         ) -> Result<u32, SpError> {
             unimplemented!()
@@ -1261,44 +1166,29 @@ mod tests {
 
         fn component_clear_status(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
             _component: SpComponent,
         ) -> Result<(), SpError> {
             unimplemented!()
         }
 
-        fn get_startup_options(
-            &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
-        ) -> Result<StartupOptions, SpError> {
+        fn get_startup_options(&mut self) -> Result<StartupOptions, SpError> {
             unimplemented!()
         }
 
         fn set_startup_options(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
             _startup_options: StartupOptions,
         ) -> Result<(), SpError> {
             unimplemented!()
         }
 
-        fn mgs_response_error(
-            &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
-            _message_id: u32,
-            _err: MgsError,
-        ) {
+        fn mgs_response_error(&mut self, _message_id: u32, _err: MgsError) {
             unimplemented!()
         }
 
         fn mgs_response_host_phase2_data(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
+            _sender: Sender,
             _message_id: u32,
             _hash: [u8; 32],
             _offset: u64,
@@ -1309,8 +1199,6 @@ mod tests {
 
         fn component_get_active_slot(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
             _component: SpComponent,
         ) -> Result<u16, SpError> {
             unimplemented!()
@@ -1318,8 +1206,6 @@ mod tests {
 
         fn component_set_active_slot(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
             _component: SpComponent,
             _slot: u16,
             _persist: bool,
@@ -1329,25 +1215,19 @@ mod tests {
 
         fn component_action(
             &mut self,
-            _sender: SocketAddrV6,
+            _sender: Sender,
             _component: SpComponent,
             _action: ComponentAction,
-        ) -> Result<(), SpError> {
+        ) -> Result<ComponentActionResponse, SpError> {
             unimplemented!()
         }
 
-        fn send_host_nmi(
-            &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
-        ) -> Result<(), SpError> {
+        fn send_host_nmi(&mut self) -> Result<(), SpError> {
             unimplemented!()
         }
 
         fn set_ipcc_key_lookup_value(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
             _key: u8,
             _value: &[u8],
         ) -> Result<(), SpError> {
@@ -1356,8 +1236,6 @@ mod tests {
 
         fn reset_component_prepare(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
             _component: SpComponent,
         ) -> Result<(), SpError> {
             unimplemented!()
@@ -1365,8 +1243,6 @@ mod tests {
 
         fn reset_component_trigger(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
             _component: SpComponent,
         ) -> Result<(), SpError> {
             unimplemented!()
@@ -1431,8 +1307,6 @@ mod tests {
 
         fn versioned_rot_boot_info(
             &mut self,
-            _sender: SocketAddrV6,
-            _port: SpPort,
             _version: u8,
         ) -> Result<RotBootInfo, SpError> {
             unimplemented!()
@@ -1457,14 +1331,14 @@ mod tests {
         let m = crate::serialize(&mut req_buf, &msg).unwrap();
 
         let mut buf = [0; crate::MAX_SERIALIZED_SIZE];
-        let n = handle_message(
-            any_socket_addr_v6(),
-            SpPort::One,
-            &req_buf[..m],
-            &mut FakeHandler,
-            &mut buf,
-        )
-        .unwrap();
+        let sender = Sender {
+            addr: any_socket_addr_v6(),
+            port: SpPort::One,
+            vid: 0x301,
+        };
+        let n =
+            handle_message(sender, &req_buf[..m], &mut FakeHandler, &mut buf)
+                .unwrap();
 
         let (resp, _) = crate::deserialize::<Message>(&buf[..n]).unwrap();
         resp
@@ -1539,25 +1413,20 @@ mod tests {
         let mut buf = [0; crate::MAX_SERIALIZED_SIZE];
 
         // ... but only the first 3 bytes (incomplete version field)
-        let n = handle_message(
-            any_socket_addr_v6(),
-            SpPort::One,
-            &req_buf[..3],
-            &mut FakeHandler,
-            &mut buf,
-        )
-        .unwrap();
+        let sender = Sender {
+            addr: any_socket_addr_v6(),
+            port: SpPort::One,
+            vid: 0x301,
+        };
+        let n =
+            handle_message(sender, &req_buf[..3], &mut FakeHandler, &mut buf)
+                .unwrap();
         let (resp1, _) = crate::deserialize::<Message>(&buf[..n]).unwrap();
 
         // ... or only the first 7 bytes (incomplete request ID field)
-        let n = handle_message(
-            any_socket_addr_v6(),
-            SpPort::One,
-            &req_buf[..7],
-            &mut FakeHandler,
-            &mut buf,
-        )
-        .unwrap();
+        let n =
+            handle_message(sender, &req_buf[..7], &mut FakeHandler, &mut buf)
+                .unwrap();
         let (resp2, _) = crate::deserialize::<Message>(&buf[..n]).unwrap();
 
         assert_eq!(resp1, resp2);

--- a/gateway-messages/tests/versioning/mod.rs
+++ b/gateway-messages/tests/versioning/mod.rs
@@ -19,6 +19,7 @@ mod v11;
 mod v12;
 mod v13;
 mod v14;
+mod v15;
 
 pub fn assert_serialized(
     out: &mut [u8],

--- a/gateway-messages/tests/versioning/mod.rs
+++ b/gateway-messages/tests/versioning/mod.rs
@@ -18,6 +18,7 @@ mod v10;
 mod v11;
 mod v12;
 mod v13;
+mod v14;
 
 pub fn assert_serialized(
     out: &mut [u8],
@@ -25,5 +26,11 @@ pub fn assert_serialized(
     item: &(impl Serialize + std::fmt::Debug),
 ) {
     let n = gateway_messages::serialize(out, item).unwrap();
+    assert_eq!(
+        n,
+        expected.len(),
+        "bad serialization size: expected {}, got {n}",
+        expected.len()
+    );
     assert_eq!(expected, &out[..n], "incorrect serialization of {item:?}");
 }

--- a/gateway-messages/tests/versioning/v14.rs
+++ b/gateway-messages/tests/versioning/v14.rs
@@ -48,7 +48,6 @@ fn monorail_component_action() {
         1, // MonorailComponentAction::Unlock
         0, // UnlockChallenge::Trivial
         0, // UnlockResponse::Trivial
-        0x34, 0x12, 0, 0, // time_s
     ];
     assert_serialized(&mut out, &expected, &action);
 
@@ -103,10 +102,8 @@ fn monorail_error() {
     .enumerate()
     {
         let err = SpError::Monorail(*e);
-
-        #[rustfmt::skip]
         let expected = vec![
-            36, // Monorail
+            36,      // Monorail
             i as u8, // error code
         ];
         assert_serialized(&mut out, &expected, &err);

--- a/gateway-messages/tests/versioning/v14.rs
+++ b/gateway-messages/tests/versioning/v14.rs
@@ -1,0 +1,114 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! This source file is named after the protocol version being tested,
+//! e.g. v01.rs implements tests for protocol version 1.
+//! The tested protocol version is represented by "$VERSION" below.
+//!
+//! The tests in this module check that the serialized form of messages from MGS
+//! protocol version $VERSION have not changed.
+//!
+//! If a test in this module fails, _do not change the test_! This means you
+//! have changed, deleted, or reordered an existing message type or enum
+//! variant, and you should revert that change. This will remain true until we
+//! bump the `version::MIN` to a value higher than $VERSION, at which point these
+//! tests can be removed as we will stop supporting $VERSION.
+
+use super::assert_serialized;
+use gateway_messages::ComponentAction;
+use gateway_messages::ComponentActionResponse;
+use gateway_messages::MonorailComponentAction;
+use gateway_messages::MonorailComponentActionResponse;
+use gateway_messages::MonorailError;
+use gateway_messages::SerializedSize;
+use gateway_messages::SpError;
+use gateway_messages::SpResponse;
+use gateway_messages::UnlockChallenge;
+use gateway_messages::UnlockResponse;
+
+#[test]
+fn monorail_component_action() {
+    let mut out = [0; ComponentAction::MAX_SIZE];
+    let action =
+        ComponentAction::Monorail(MonorailComponentAction::RequestChallenge);
+    let expected = vec![
+        1, // Monorail
+        0, // RequestChallenge
+    ];
+    assert_serialized(&mut out, &expected, &action);
+
+    let action = ComponentAction::Monorail(MonorailComponentAction::Unlock {
+        challenge: UnlockChallenge::Trivial,
+        response: UnlockResponse::Trivial,
+        time_sec: 0x1234,
+    });
+    let expected = vec![
+        1, // ComponentAction::Monorail
+        1, // MonorailComponentAction::Unlock
+        0, // UnlockChallenge::Trivial
+        0, // UnlockResponse::Trivial
+        0x34, 0x12, 0, 0, // time_s
+    ];
+    assert_serialized(&mut out, &expected, &action);
+
+    let action = ComponentAction::Monorail(MonorailComponentAction::Lock);
+    let expected = vec![
+        1, // Monorail
+        2, // Lock
+    ];
+    assert_serialized(&mut out, &expected, &action);
+}
+#[test]
+fn component_action_response() {
+    let mut out = [0; SpResponse::MAX_SIZE];
+
+    let r = SpResponse::ComponentAction(ComponentActionResponse::Ack);
+    let expected = vec![
+        46, // ComponentAction
+        0,  // Ack
+    ];
+    assert_serialized(&mut out, &expected, &r);
+
+    let r = SpResponse::ComponentAction(ComponentActionResponse::Monorail(
+        MonorailComponentActionResponse::RequestChallenge(
+            UnlockChallenge::Trivial,
+        ),
+    ));
+    let expected = vec![
+        46, // ComponentAction
+        1,  // Ack
+        0,  // RequestChallenge
+        0,  // Trivial
+    ];
+    assert_serialized(&mut out, &expected, &r);
+}
+
+#[test]
+fn monorail_error() {
+    let mut out = [0; ComponentAction::MAX_SIZE];
+
+    for (i, e) in [
+        MonorailError::UnlockAuthFailed,
+        MonorailError::UnlockFailed,
+        MonorailError::LockFailed,
+        MonorailError::ManagementNetworkLocked,
+        MonorailError::InvalidVLAN,
+        MonorailError::GetChallengeFailed,
+        MonorailError::TimeIsTooLong,
+        MonorailError::ChallengeExpired,
+        MonorailError::AlreadyTrusted,
+    ]
+    .iter()
+    .enumerate()
+    {
+        let err = SpError::Monorail(*e);
+
+        #[rustfmt::skip]
+        let expected = vec![
+            36, // Monorail
+            i as u8, // error code
+        ];
+        assert_serialized(&mut out, &expected, &err);
+    }
+}

--- a/gateway-messages/tests/versioning/v15.rs
+++ b/gateway-messages/tests/versioning/v15.rs
@@ -1,0 +1,133 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! This source file is named after the protocol version being tested,
+//! e.g. v01.rs implements tests for protocol version 1.
+//! The tested protocol version is represented by "$VERSION" below.
+//!
+//! The tests in this module check that the serialized form of messages from MGS
+//! protocol version $VERSION have not changed.
+//!
+//! If a test in this module fails, _do not change the test_! This means you
+//! have changed, deleted, or reordered an existing message type or enum
+//! variant, and you should revert that change. This will remain true until we
+//! bump the `version::MIN` to a value higher than $VERSION, at which point these
+//! tests can be removed as we will stop supporting $VERSION.
+
+use super::assert_serialized;
+use gateway_messages::ComponentAction;
+use gateway_messages::ComponentActionResponse;
+use gateway_messages::MonorailComponentAction;
+use gateway_messages::MonorailComponentActionResponse;
+use gateway_messages::SerializedSize;
+use gateway_messages::SpResponse;
+use gateway_messages::UnlockChallenge;
+use gateway_messages::UnlockResponse;
+
+#[test]
+fn monorail_component_action() {
+    let mut out = [0; ComponentAction::MAX_SIZE];
+    let action =
+        ComponentAction::Monorail(MonorailComponentAction::RequestChallenge);
+    let expected = vec![
+        1, // Monorail
+        0, // RequestChallenge
+    ];
+    assert_serialized(&mut out, &expected, &action);
+
+    #[rustfmt::skip]
+    let action = ComponentAction::Monorail(MonorailComponentAction::Unlock {
+        challenge: UnlockChallenge::EcdsaSha2Nistp256([
+            1, 2, 3, 4, 5, 6, 7, 8,
+            1, 2, 3, 4, 5, 6, 7, 8,
+            1, 2, 3, 4, 5, 6, 7, 8,
+            1, 2, 3, 4, 5, 6, 7, 8,
+        ]),
+        response: UnlockResponse::EcdsaSha2Nistp256 {
+            key: [
+                123,
+                1, 1, 1, 1, 1, 1, 1, 1,
+                2, 2, 2, 2, 2, 2, 2, 2,
+                3, 3, 3, 3, 3, 3, 3, 3,
+                4, 4, 4, 4, 4, 4, 4, 4,
+                5, 5, 5, 5, 5, 5, 5, 5,
+                6, 6, 6, 6, 6, 6, 6, 6,
+                7, 7, 7, 7, 7, 7, 7, 7,
+                8, 8, 8, 8, 8, 8, 8, 8,
+            ],
+            signature: [
+                8, 8, 8, 8, 8, 8, 8, 8,
+                7, 7, 7, 7, 7, 7, 7, 7,
+                6, 6, 6, 6, 6, 6, 6, 6,
+                5, 5, 5, 5, 5, 5, 5, 5,
+                4, 4, 4, 4, 4, 4, 4, 4,
+                3, 3, 3, 3, 3, 3, 3, 3,
+                2, 2, 2, 2, 2, 2, 2, 2,
+                1, 1, 1, 1, 1, 1, 1, 1,
+            ],
+        },
+        time_sec: 0x1234,
+    });
+    #[rustfmt::skip]
+    let expected = vec![
+        1, // ComponentAction::Monorail
+        1, // MonorailComponentAction::Unlock
+        1, // UnlockChallenge::EcdsaSha2Nistp256
+        1, 2, 3, 4, 5, 6, 7, 8,
+        1, 2, 3, 4, 5, 6, 7, 8,
+        1, 2, 3, 4, 5, 6, 7, 8,
+        1, 2, 3, 4, 5, 6, 7, 8,
+
+        1, // UnlockResponse::EcdsaSha2Nistp256
+        123, // key
+        1, 1, 1, 1, 1, 1, 1, 1,
+        2, 2, 2, 2, 2, 2, 2, 2,
+        3, 3, 3, 3, 3, 3, 3, 3,
+        4, 4, 4, 4, 4, 4, 4, 4,
+        5, 5, 5, 5, 5, 5, 5, 5,
+        6, 6, 6, 6, 6, 6, 6, 6,
+        7, 7, 7, 7, 7, 7, 7, 7,
+        8, 8, 8, 8, 8, 8, 8, 8,
+
+        8, 8, 8, 8, 8, 8, 8, 8, // signature
+        7, 7, 7, 7, 7, 7, 7, 7,
+        6, 6, 6, 6, 6, 6, 6, 6,
+        5, 5, 5, 5, 5, 5, 5, 5,
+        4, 4, 4, 4, 4, 4, 4, 4,
+        3, 3, 3, 3, 3, 3, 3, 3,
+        2, 2, 2, 2, 2, 2, 2, 2,
+        1, 1, 1, 1, 1, 1, 1, 1,
+
+        0x34, 0x12, 0, 0, // time_s
+    ];
+    assert_serialized(&mut out, &expected, &action);
+}
+#[test]
+fn component_action_response() {
+    let mut out = [0; SpResponse::MAX_SIZE];
+
+    #[rustfmt::skip]
+    let r = SpResponse::ComponentAction(ComponentActionResponse::Monorail(
+        MonorailComponentActionResponse::RequestChallenge(
+            UnlockChallenge::EcdsaSha2Nistp256([
+                1, 2, 3, 4, 5, 6, 7, 8,
+                2, 2, 3, 4, 5, 6, 7, 8,
+                1, 2, 3, 4, 5, 6, 7, 9,
+                3, 2, 3, 4, 5, 6, 7, 8,
+            ]),
+        ),
+    ));
+    #[rustfmt::skip]
+    let expected = vec![
+        46, // ComponentAction
+        1,  // Ack
+        0,  // RequestChallenge
+        1,  // EcdsaSha2Nistp256
+        1, 2, 3, 4, 5, 6, 7, 8, // array
+        2, 2, 3, 4, 5, 6, 7, 8,
+        1, 2, 3, 4, 5, 6, 7, 9,
+        3, 2, 3, 4, 5, 6, 7, 8,
+    ];
+    assert_serialized(&mut out, &expected, &r);
+}

--- a/gateway-sp-comms/src/sp_response_expect.rs
+++ b/gateway-sp-comms/src/sp_response_expect.rs
@@ -5,6 +5,7 @@
 use crate::error::CommunicationError;
 use crate::VersionedSpState;
 use gateway_messages::ignition::LinkEvents;
+use gateway_messages::ComponentActionResponse;
 use gateway_messages::DiscoverResponse;
 use gateway_messages::IgnitionState;
 use gateway_messages::PowerState;
@@ -115,6 +116,7 @@ expect_fn!(ResetComponentPrepareAck);
 expect_fn!(ResetComponentTriggerAck);
 expect_fn!(SwitchDefaultImageAck);
 expect_fn!(ComponentActionAck);
+expect_fn!(ComponentAction(resp) -> ComponentActionResponse);
 expect_fn!(ReadSensor(resp) -> SensorResponse);
 expect_fn!(CurrentTime(time) -> u64);
 expect_fn!(DisableComponentWatchdogAck);


### PR DESCRIPTION
This PR adds tech port unlocking as described in [RFD 492](https://rfd.shared.oxide.computer/rfd/492).

It should be read alongside the corresponding Hubris PR (https://github.com/oxidecomputer/hubris/pull/1832)

There are a bunch of changes, which I'll summarize below.

## Adding the `Sender` type
```rust
pub struct Sender {
    /// Address of the sender
    pub addr: SocketAddrV6,
    /// SP port on which the packet was received
    pub port: SpPort,
    /// VLAN tag associated with the received packet
    ///
    /// This is often one-to-one equivalent to `port`; however, on Sidecar,
    /// multiple VLANs are mapped to `SpPort::One`.
    pub vid: u16,
}
```
This type is passed as an argument to `SpImpl` functions that care about the sender.  For functions which do not care about the sender, the pre-existing `sender: SocketAddrV6, port: SpPort,` arguments have been removed.

## Allow `ComponentAction` to return data
Added `enum ComponentActionResponse` as the return type for `SpImpl::component_action`, so that component actions can return data.

For backwards compatibility, `ComponentActionResponse::Ack` is translated into `SpResponse::ComponentActionAck`.

## Added new types
`MonorailComponentAction`, `MonorailComponentActionResponse`, `UnlockChallenge`, `UnlockResponse`; all of the pieces to perform tech port unlocking.

## Add `monorail lock/unlock` subcommand to `faux-mgs`
This is where the locking and unlocking actually gets done!