### PR TITLE
Make `SingleSp::set_power_state` idempotent

### DIFF
--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -651,6 +651,17 @@ impl SingleSp {
 
     /// Set the current power state.
     pub async fn set_power_state(&self, power_state: PowerState) -> Result<()> {
+        // First, let's make sure the system isn't already *in* the desired power
+        // state --- the SP will return an error if we try to set the power
+        // state to the state it's already in.
+        if power_state == self.power_state().await? {
+            trace!(
+                &self.log,
+                "already in the desired power state, doing nothing";
+                "power_state" => ?power_state,
+            );
+            return Ok(());
+        }
         self.rpc(MgsRequest::SetPowerState(power_state))
             .await
             .and_then(expect_set_power_state_ack)


### PR DESCRIPTION
Presently, the `SingleSp::set_power_state` method can fail if the system
is already in the requested power state, which is a bit of a bummer.
This is because the Hubris sequencer task returns an `IllegalTransition`
error when the requested and current power states are the same.

This commit changes it to first check the power state, and not ask the
SP to do anything else if it's already in the requested state.

Closes #270