### PR TITLE
Fix crash during Tokio runtime teardown

### DIFF
--- a/gateway-sp-comms/src/shared_socket.rs
+++ b/gateway-sp-comms/src/shared_socket.rs
@@ -353,11 +353,15 @@ impl SingleSpHandle {
         })
     }
 
-    pub(crate) async fn recv(&mut self) -> SingleSpMessage {
+    pub(crate) async fn recv(&mut self) -> Option<SingleSpMessage> {
         // If `recv()` returns `None`, the `RecvHandler` task associated with
         // the shared socket we're using has panicked; we'll propagate that
         // panic.
-        self.recv.recv().await.expect("recv() task died")
+        let m = self.recv.recv().await;
+        if m.is_none() {
+            warn!(self.log, "recv() task died; we are hopefully exiting");
+        }
+        m
     }
 }
 

--- a/gateway-sp-comms/src/shared_socket.rs
+++ b/gateway-sp-comms/src/shared_socket.rs
@@ -355,8 +355,11 @@ impl SingleSpHandle {
 
     pub(crate) async fn recv(&mut self) -> Option<SingleSpMessage> {
         // If `recv()` returns `None`, the `RecvHandler` task associated with
-        // the shared socket we're using has panicked; we'll propagate that
-        // panic.
+        // the shared socket we're using has panicked, or we're in Tokio runtime
+        // shutdown (where tasks are destroyed in arbitrary order).  Relevant
+        // executables are compiled with `panic = abort`, so this is probably
+        // the latter; we'll log the error but not panic ourselves (to avoid
+        // spurious panics at shutdown).
         let m = self.recv.recv().await;
         if m.is_none() {
             warn!(self.log, "recv() task died; we are hopefully exiting");

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -1581,9 +1581,9 @@ impl InnerSocket for InnerSocketWrapper {
 
     // This function is only used if we were created with
     // `new_direct_socket_for_testing()`, so we're a little lazy with error
-    // handling. The real `SingleSpHandle` handles errors internally, so this
-    // `recv()` is defined as infallible in our trait that wraps both the real
-    // handle and this wrapper-for-tests.
+    // handling. The real `SingleSpHandle` handles errors internally but may
+    // return `None` at runtime shutdown; this `recv()` is more infallible
+    // (always returning `Some(..)`)
     async fn recv(&mut self) -> Option<SingleSpMessage> {
         let mut buf = [0; gateway_messages::MAX_SERIALIZED_SIZE];
         loop {


### PR DESCRIPTION
While testing #274, I saw occasional panics during shutdown:

```
matt@jeeves ~ () $ env RUST_BACKTRACE=1 pfexec ./faux-mgs --discovery-addr='[fe80::aa40:25ff:fe05:100]:11111' --interface madrid_sw0tp0 monorail unlock --list
Aug 28 15:56:50.742 INFO creating SP handle on interface madrid_sw0tp0, component: faux-mgs
ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBN7s3QT4S6Xmtqgd3z2/8LGOMk601NRGtKAehoDWki7AfVXZGvca33dvsi5so0EkndJhi+rwDNB0KxzeQq6iKY0= PIV_slot_9A /CN=oxide-support-001-auth
done
thread 'tokio-runtime-worker' panicked at gateway-sp-comms/src/shared_socket.rs:362:32:
recv() task died
stack backtrace:
   0: rust_begin_unwind
             at /rustc/a28077b28a02b92985b3a3faecf92813155f1ea1/library/std/src/panicking.rs:597:5
   1: core::panicking::panic_fmt
             at /rustc/a28077b28a02b92985b3a3faecf92813155f1ea1/library/core/src/panicking.rs:72:14
   2: core::panicking::panic_display
             at /rustc/a28077b28a02b92985b3a3faecf92813155f1ea1/library/core/src/panicking.rs:168:5
   3: core::panicking::panic_str
             at /rustc/a28077b28a02b92985b3a3faecf92813155f1ea1/library/core/src/panicking.rs:152:5
   4: core::option::expect_failed
             at /rustc/a28077b28a02b92985b3a3faecf92813155f1ea1/library/core/src/option.rs:1988:5
   5: <gateway_sp_comms::shared_socket::SingleSpHandle as gateway_sp_comms::single_sp::InnerSocket>::recv::{{closure}}
   6: <tokio::future::poll_fn::PollFn<F> as core::future::future::Future>::poll
   7: gateway_sp_comms::single_sp::Inner<T>::rpc_call::{{closure}}
   8: gateway_sp_comms::single_sp::Inner<T>::discover::{{closure}}
   9: gateway_sp_comms::single_sp::Inner<T>::run::{{closure}}
  10: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
  11: tokio::runtime::task::core::Core<T,S>::poll
  12: tokio::runtime::task::harness::Harness<T,S>::poll
  13: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
  14: tokio::runtime::scheduler::multi_thread::worker::Context::run
  15: tokio::runtime::context::runtime::enter_runtime
  16: tokio::runtime::scheduler::multi_thread::worker::run
  17: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
  18: tokio::runtime::task::core::Core<T,S>::poll
  19: tokio::runtime::task::harness::Harness<T,S>::poll
  20: tokio::runtime::blocking::pool::Inner::run
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

This is the same issue discussed in [my blog post](https://www.mattkeeter.com/blog/2024-08-01-panic/): tasks are destroyed in arbitrary order, so the task owning the `mpsc::Sender` can be destroyed while the other task is still trying to read from it.

The fix is to make `recv()` return an `Option<SingleSpMessage>`, and then do all of the plumbing necessary to make the compiler happy.