### PR TITLE
Add `MeasurementKind::Dimensionless`

### DIFF
--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -66,7 +66,7 @@ pub const ROT_PAGE_SIZE: usize = 512;
 /// for more detail and discussion.
 pub mod version {
     pub const MIN: u32 = 2;
-    pub const CURRENT: u32 = 15;
+    pub const CURRENT: u32 = 16;
 
     /// MGS protocol version in which SP watchdog messages were added
     pub const WATCHDOG_VERSION: u32 = 12;

--- a/gateway-messages/src/sp_to_mgs/measurement.rs
+++ b/gateway-messages/src/sp_to_mgs/measurement.rs
@@ -67,6 +67,5 @@ pub enum MeasurementKind {
     InputCurrent,
     InputVoltage,
     Speed,
-    /// A dimensionless measurement, without units.
-    Dimensionless,
+    CpuTctl,
 }

--- a/gateway-messages/src/sp_to_mgs/measurement.rs
+++ b/gateway-messages/src/sp_to_mgs/measurement.rs
@@ -67,4 +67,6 @@ pub enum MeasurementKind {
     InputCurrent,
     InputVoltage,
     Speed,
+    /// A dimensionless measurement, without units.
+    Dimensionless,
 }

--- a/gateway-messages/tests/versioning/mod.rs
+++ b/gateway-messages/tests/versioning/mod.rs
@@ -20,6 +20,7 @@ mod v12;
 mod v13;
 mod v14;
 mod v15;
+mod v16;
 
 pub fn assert_serialized(
     out: &mut [u8],

--- a/gateway-messages/tests/versioning/v16.rs
+++ b/gateway-messages/tests/versioning/v16.rs
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! This source file is named after the protocol version being tested,
+//! e.g. v01.rs implements tests for protocol version 1.
+//! The tested protocol version is represented by "$VERSION" below.
+//!
+//! The tests in this module check that the serialized form of messages from MGS
+//! protocol version $VERSION have not changed.
+//!
+//! If a test in this module fails, _do not change the test_! This means you
+//! have changed, deleted, or reordered an existing message type or enum
+//! variant, and you should revert that change. This will remain true until we
+//! bump the `version::MIN` to a value higher than $VERSION, at which point these
+//! tests can be removed as we will stop supporting $VERSION.
+
+use super::assert_serialized;
+use gateway_messages::measurement::MeasurementKind;
+use gateway_messages::SerializedSize;
+use gateway_messages::SpResponse;
+
+#[test]
+fn measurement_kinds() {
+    let mut out = [0; SpResponse::MAX_SIZE];
+
+    for (kind, serialized) in [
+        (MeasurementKind::Temperature, &[0]),
+        (MeasurementKind::Power, &[1]),
+        (MeasurementKind::Current, &[2]),
+        (MeasurementKind::Voltage, &[3]),
+        (MeasurementKind::InputCurrent, &[4]),
+        (MeasurementKind::InputVoltage, &[5]),
+        (MeasurementKind::Speed, &[6]),
+        (MeasurementKind::CpuTctl, &[7]),
+    ] {
+        assert_serialized(&mut out, serialized, &kind);
+    }
+}


### PR DESCRIPTION
This commit adds a `CpuTctl` variant to the `MeasurementKind` enum. This
is intended to be used to represent AMD CPU T<sub>ctl</sub> thermal
values, which are a unitless value from 0-100 representing a kind of
"abstract thermal throttling danger level" --- see
oxidecomputer/hubris#1881 for details on why we need to differentiate
this from other temperature measurements.