### PR TITLE
Automatic sizing in `assert_serialized`

### DIFF
--- a/gateway-messages/tests/versioning/mod.rs
+++ b/gateway-messages/tests/versioning/mod.rs
@@ -4,6 +4,7 @@
 
 // Copyright 2023 Oxide Computer Company
 
+use hubpack::SerializedSize;
 use serde::Serialize;
 
 mod v02;
@@ -22,12 +23,12 @@ mod v14;
 mod v15;
 mod v16;
 
-pub fn assert_serialized(
-    out: &mut [u8],
+pub fn assert_serialized<T: Serialize + SerializedSize + std::fmt::Debug>(
     expected: &[u8],
-    item: &(impl Serialize + std::fmt::Debug),
+    item: &T,
 ) {
-    let n = gateway_messages::serialize(out, item).unwrap();
+    let mut out = vec![0u8; T::MAX_SIZE];
+    let n = gateway_messages::serialize(&mut out, item).unwrap();
     assert_eq!(
         n,
         expected.len(),

--- a/gateway-messages/tests/versioning/v02.rs
+++ b/gateway-messages/tests/versioning/v02.rs
@@ -41,7 +41,6 @@ use gateway_messages::RotImageDetails;
 use gateway_messages::RotSlotId;
 use gateway_messages::RotState;
 use gateway_messages::RotUpdateDetails;
-use gateway_messages::SerializedSize;
 use gateway_messages::SpComponent;
 use gateway_messages::SpError;
 use gateway_messages::SpPort;
@@ -67,7 +66,6 @@ use super::assert_serialized;
 // variants are covered in additional tests below.
 #[test]
 fn message() {
-    let mut out = [0; Message::MAX_SIZE];
     let header = Header { version: 2, message_id: 0x01020304 };
 
     #[rustfmt::skip]
@@ -82,7 +80,7 @@ fn message() {
     ];
     let message =
         Message { header, kind: MessageKind::MgsRequest(MgsRequest::Discover) };
-    assert_serialized(&mut out, expected, &message);
+    assert_serialized(expected, &message);
 
     #[rustfmt::skip]
     let expected = &[
@@ -102,7 +100,7 @@ fn message() {
             MgsError::BadRequest(BadRequestReason::WrongDirection),
         )),
     };
-    assert_serialized(&mut out, expected, &message);
+    assert_serialized(expected, &message);
 
     #[rustfmt::skip]
     let expected = &[
@@ -123,7 +121,7 @@ fn message() {
             offset: 0x0102_0304_0506_0708,
         }),
     };
-    assert_serialized(&mut out, expected, &message);
+    assert_serialized(expected, &message);
 
     #[rustfmt::skip]
     let expected = &[
@@ -139,24 +137,22 @@ fn message() {
         header,
         kind: MessageKind::SpResponse(SpResponse::SpUpdatePrepareAck),
     };
-    assert_serialized(&mut out, expected, &message);
+    assert_serialized(expected, &message);
 }
 
 #[test]
 fn mgs_request() {
-    let mut out = [0; MgsRequest::MAX_SIZE];
-
     let request = MgsRequest::Discover;
     let expected = &[0];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::IgnitionState { target: 7 };
     let expected = &[1, 7];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::BulkIgnitionState { offset: 0x01020304 };
     let expected = &[2, 4, 3, 2, 1];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     for (command, command_val) in [
         (IgnitionCommand::PowerOn, 0),
@@ -165,25 +161,25 @@ fn mgs_request() {
     ] {
         let request = MgsRequest::IgnitionCommand { target: 7, command };
         let expected = &[3, 7, command_val];
-        assert_serialized(&mut out, expected, &request);
+        assert_serialized(expected, &request);
     }
 
     let request = MgsRequest::SpState;
     let expected = &[4];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::SerialConsoleAttach(SpComponent::SP_ITSELF);
     let expected = &[5, b's', b'p', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request =
         MgsRequest::SerialConsoleWrite { offset: 0x0102_0304_0506_0708 };
     let expected = &[6, 8, 7, 6, 5, 4, 3, 2, 1];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::SerialConsoleDetach;
     let expected = &[7];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::SpUpdatePrepare(SpUpdatePrepare {
         id: UpdateId([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
@@ -208,7 +204,7 @@ fn mgs_request() {
 
         0xf3, 0xf2, 0xf1, 0xf0, // sp_image_size
     ];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::ComponentUpdatePrepare(ComponentUpdatePrepare {
         component: SpComponent::SP_ITSELF,
@@ -224,7 +220,7 @@ fn mgs_request() {
         2, 1, // slot
         6, 5, 4, 3, // total_size
     ];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::UpdateChunk(UpdateChunk {
         component: SpComponent::SP_ITSELF,
@@ -238,11 +234,11 @@ fn mgs_request() {
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, // id
         6, 5, 4, 3, // offset
     ];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::UpdateStatus(SpComponent::SP_ITSELF);
     let expected = &[11, b's', b'p', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::UpdateAbort {
         component: SpComponent::SP_ITSELF,
@@ -254,35 +250,35 @@ fn mgs_request() {
         b's', b'p', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // SP_ITSELF
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, // id
     ];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::GetPowerState;
     let expected = &[13];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     for (state, state_val) in
         [(PowerState::A0, 0), (PowerState::A1, 1), (PowerState::A2, 2)]
     {
         let request = MgsRequest::SetPowerState(state);
         let expected = &[14, state_val];
-        assert_serialized(&mut out, expected, &request);
+        assert_serialized(expected, &request);
     }
 
     let request = MgsRequest::ResetPrepare;
     let expected = &[15];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::ResetTrigger;
     let expected = &[16];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::Inventory { device_index: 0x01020304 };
     let expected = &[17, 4, 3, 2, 1];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::GetStartupOptions;
     let expected = &[18];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let options = StartupOptions::PHASE2_RECOVERY_MODE
         | StartupOptions::STARTUP_KBM
@@ -292,7 +288,7 @@ fn mgs_request() {
     assert_eq!(options.bits(), 0x0000_0000_0000_0153);
     let request = MgsRequest::SetStartupOptions(options);
     let expected = &[19, 0x53, 0x01, 0, 0, 0, 0, 0, 0];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::ComponentDetails {
         component: SpComponent::SP_ITSELF,
@@ -304,15 +300,15 @@ fn mgs_request() {
         b's', b'p', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // SP_ITSELF
         6, 5, 4, 3, // offset
     ];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::IgnitionLinkEvents { target: 7 };
     let expected = &[21, 7];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::BulkIgnitionLinkEvents { offset: 0x01020304 };
     let expected = &[22, 4, 3, 2, 1];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     for (target, target_val, xvr_select, xvr_select_val) in [
         (None, &[0_u8] as &[u8], None, &[0_u8] as &[u8]),
@@ -327,7 +323,7 @@ fn mgs_request() {
         let mut expected = vec![23];
         expected.extend_from_slice(target_val);
         expected.extend_from_slice(xvr_select_val);
-        assert_serialized(&mut out, &expected, &request);
+        assert_serialized(&expected, &request);
     }
 
     let request = MgsRequest::ComponentClearStatus(SpComponent::SP_ITSELF);
@@ -336,7 +332,7 @@ fn mgs_request() {
         24, // ComponentClearStatus
         b's', b'p', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // SP_ITSELF
     ];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::ComponentGetActiveSlot(SpComponent::SP_ITSELF);
     #[rustfmt::skip]
@@ -344,7 +340,7 @@ fn mgs_request() {
         25, // ComponentGetActiveSlot
         b's', b'p', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // SP_ITSELF
     ];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::ComponentSetActiveSlot {
         component: SpComponent::SP_ITSELF,
@@ -356,19 +352,19 @@ fn mgs_request() {
         b's', b'p', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // SP_ITSELF
         2, 1, // slot
     ];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::SerialConsoleBreak;
     let expected = &[27];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::SendHostNmi;
     let expected = &[28];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::SetIpccKeyLookupValue { key: 7 };
     let expected = &[29, 7];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::ComponentSetAndPersistActiveSlot {
         component: SpComponent::SP_ITSELF,
@@ -380,25 +376,25 @@ fn mgs_request() {
         b's', b'p', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // SP_ITSELF
         2, 1, // slot
     ];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::ReadCaboose { key: [1, 2, 3, 4] };
     let expected = &[31, 1, 2, 3, 4];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::SerialConsoleKeepAlive;
     let expected = &[32];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request =
         MgsRequest::ResetComponentPrepare { component: SpComponent::SP_ITSELF };
     let expected = &[33, 115, 112, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request =
         MgsRequest::ResetComponentTrigger { component: SpComponent::SP_ITSELF };
     let expected = &[34, 115, 112, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::SwitchDefaultImage {
         component: SpComponent::ROT,
@@ -407,36 +403,34 @@ fn mgs_request() {
     };
     let expected =
         &[35, 114, 111, 116, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 }
 
 #[test]
 fn mgs_response() {
-    let mut out = [0; MgsResponse::MAX_SIZE];
-
     let response = MgsResponse::Error(MgsError::BadRequest(
         BadRequestReason::WrongVersion { sp: 0x01020304, request: 0x05060708 },
     ));
     let expected = &[0, 0, 0, 4, 3, 2, 1, 8, 7, 6, 5];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = MgsResponse::Error(MgsError::BadRequest(
         BadRequestReason::WrongDirection,
     ));
     let expected = &[0, 0, 1];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = MgsResponse::Error(MgsError::BadRequest(
         BadRequestReason::UnexpectedTrailingData,
     ));
     let expected = &[0, 0, 2];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = MgsResponse::Error(MgsError::BadRequest(
         BadRequestReason::DeserializationError,
     ));
     let expected = &[0, 0, 3];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = MgsResponse::Error(MgsError::HostPhase2Unavailable {
         hash: [
@@ -448,7 +442,7 @@ fn mgs_response() {
         0, 1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
         19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
     ];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = MgsResponse::Error(MgsError::HostPhase2ImageBadOffset {
         hash: [
@@ -462,7 +456,7 @@ fn mgs_response() {
         19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 0xa7, 0xa6,
         0xa5, 0xa4, 0xa3, 0xa2, 0xa1, 0xa0,
     ];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = MgsResponse::HostPhase2Data {
         hash: [
@@ -476,13 +470,11 @@ fn mgs_response() {
         20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 0xa7, 0xa6, 0xa5,
         0xa4, 0xa3, 0xa2, 0xa1, 0xa0,
     ];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 }
 
 #[test]
 fn sp_request() {
-    let mut out = [0; SpRequest::MAX_SIZE];
-
     let request = SpRequest::SerialConsole {
         component: SpComponent::SP_ITSELF,
         offset: 0x0102_0304_0506_0708,
@@ -493,7 +485,7 @@ fn sp_request() {
         b's', b'p', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // SP_ITSELF
         8, 7, 6, 5, 4, 3, 2, 1, // offset
     ];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = SpRequest::HostPhase2Data {
         hash: [
@@ -507,22 +499,20 @@ fn sp_request() {
         20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 0xa7, 0xa6, 0xa5,
         0xa4, 0xa3, 0xa2, 0xa1, 0xa0,
     ];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 }
 
 #[test]
 fn sp_response() {
-    let mut out = [0; SpResponse::MAX_SIZE];
-
     let response =
         SpResponse::Discover(DiscoverResponse { sp_port: SpPort::One });
     let expected = &[0, 1];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response =
         SpResponse::Discover(DiscoverResponse { sp_port: SpPort::Two });
     let expected = &[0, 2];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::IgnitionState(IgnitionState {
         receiver: ReceiverStatus {
@@ -533,7 +523,7 @@ fn sp_response() {
         target: None,
     });
     let expected = &[1, 1, 1, 1, 0];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     for (system_type, system_type_val) in [
         (SystemType::Gimlet, &[0_u8] as &[_]),
@@ -594,7 +584,7 @@ fn sp_response() {
                 1, 0, 0, // link0_receiver_status
                 0, 1, 1, // link1_receiver_status
             ]);
-            assert_serialized(&mut out, &expected, &response);
+            assert_serialized(&expected, &response);
         }
     }
 
@@ -603,11 +593,11 @@ fn sp_response() {
         total: 0x05060708,
     });
     let expected = &[2, 4, 3, 2, 1, 8, 7, 6, 5];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::IgnitionCommandAck;
     let expected = &[3];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     for (rot, rot_val) in [
         (
@@ -723,21 +713,21 @@ fn sp_response() {
             ];
             expected.push(power_state_val);
             expected.extend_from_slice(rot_val);
-            assert_serialized(&mut out, &expected, &response);
+            assert_serialized(&expected, &response);
         }
     }
 
     let response = SpResponse::SpUpdatePrepareAck;
     let expected = &[5];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::ComponentUpdatePrepareAck;
     let expected = &[6];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::UpdateChunkAck;
     let expected = &[7];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     for (status, status_val) in [
         (UpdateStatus::None, &[0_u8] as &[_]),
@@ -819,49 +809,49 @@ fn sp_response() {
         let response = SpResponse::UpdateStatus(status);
         let mut expected = vec![8];
         expected.extend_from_slice(status_val);
-        assert_serialized(&mut out, &expected, &response);
+        assert_serialized(&expected, &response);
     }
 
     let response = SpResponse::UpdateAbortAck;
     let expected = &[9];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::SerialConsoleAttachAck;
     let expected = &[10];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::SerialConsoleWriteAck {
         furthest_ingested_offset: 0x0102_0304_0506_0708,
     };
     let expected = &[11, 8, 7, 6, 5, 4, 3, 2, 1];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::SerialConsoleDetachAck;
     let expected = &[12];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     for (power_state, power_state_val) in
         [(PowerState::A0, 0), (PowerState::A1, 1), (PowerState::A2, 2)]
     {
         let response = SpResponse::PowerState(power_state);
         let expected = &[13, power_state_val];
-        assert_serialized(&mut out, expected, &response);
+        assert_serialized(expected, &response);
     }
 
     let response = SpResponse::SetPowerStateAck;
     let expected = &[14];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::ResetPrepareAck;
     let expected = &[15];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::Inventory(TlvPage {
         offset: 0x01020304,
         total: 0x05060708,
     });
     let expected = &[16, 4, 3, 2, 1, 8, 7, 6, 5];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     for (error, error_val) in [
         (SpError::Busy, &[0_u8] as &[_]),
@@ -941,7 +931,7 @@ fn sp_response() {
         let response = SpResponse::Error(error);
         let mut expected = vec![17];
         expected.extend_from_slice(error_val);
-        assert_serialized(&mut out, &expected, &response);
+        assert_serialized(&expected, &response);
     }
 
     let options = StartupOptions::PHASE2_RECOVERY_MODE
@@ -952,18 +942,18 @@ fn sp_response() {
     assert_eq!(options.bits(), 0x0000_0000_0000_0153);
     let response = SpResponse::StartupOptions(options);
     let expected = &[18, 0x53, 0x01, 0, 0, 0, 0, 0, 0];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::SetStartupOptionsAck;
     let expected = &[19];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::ComponentDetails(TlvPage {
         offset: 0x01020304,
         total: 0x05060708,
     });
     let expected = &[20, 4, 3, 2, 1, 8, 7, 6, 5];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::IgnitionLinkEvents(LinkEvents {
         controller: TransceiverEvents {
@@ -992,64 +982,64 @@ fn sp_response() {
         },
     });
     let expected = &[21, 1, 0, 1, 0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 0, 1];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::BulkIgnitionLinkEvents(TlvPage {
         offset: 0x01020304,
         total: 0x05060708,
     });
     let expected = &[22, 4, 3, 2, 1, 8, 7, 6, 5];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::ClearIgnitionLinkEventsAck;
     let expected = &[23];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::ComponentClearStatusAck;
     let expected = &[24];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::ComponentActiveSlot(0x0102);
     let expected = &[25, 2, 1];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::ComponentSetActiveSlotAck;
     let expected = &[26];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::SerialConsoleBreakAck;
     let expected = &[27];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::SendHostNmiAck;
     let expected = &[28];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::SetIpccKeyLookupValueAck;
     let expected = &[29];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::ComponentSetAndPersistActiveSlotAck;
     let expected = &[30];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::CabooseValue;
     let expected = &[31];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::SerialConsoleKeepAliveAck;
     let expected = &[32];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::ResetComponentPrepareAck;
     let expected = &[33];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::ResetComponentTriggerAck;
     let expected = &[34];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 
     let response = SpResponse::SwitchDefaultImageAck;
     let expected = &[35];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 }

--- a/gateway-messages/tests/versioning/v03.rs
+++ b/gateway-messages/tests/versioning/v03.rs
@@ -16,7 +16,6 @@
 use gateway_messages::ComponentAction;
 use gateway_messages::LedComponentAction;
 use gateway_messages::MgsRequest;
-use gateway_messages::SerializedSize;
 use gateway_messages::SpComponent;
 use gateway_messages::SpResponse;
 
@@ -25,34 +24,31 @@ use super::assert_serialized;
 // This test covers the ComponentAction message added in v3.
 #[test]
 fn mgs_request() {
-    let mut out = [0; MgsRequest::MAX_SIZE];
-
     let request = MgsRequest::ComponentAction {
         component: SpComponent::SYSTEM_LED,
         action: ComponentAction::Led(LedComponentAction::TurnOn),
     };
     let expected = b"\x24system-led\0\0\0\0\0\0\0\0";
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::ComponentAction {
         component: SpComponent::SYSTEM_LED,
         action: ComponentAction::Led(LedComponentAction::TurnOff),
     };
     let expected = b"\x24system-led\0\0\0\0\0\0\0\x01";
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 
     let request = MgsRequest::ComponentAction {
         component: SpComponent::SYSTEM_LED,
         action: ComponentAction::Led(LedComponentAction::Blink),
     };
     let expected = b"\x24system-led\0\0\0\0\0\0\0\x02";
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 }
 
 #[test]
 fn sp_response() {
-    let mut out = [0; SpResponse::MAX_SIZE];
     let response = SpResponse::ComponentActionAck;
     let expected = &[36];
-    assert_serialized(&mut out, expected, &response);
+    assert_serialized(expected, &response);
 }

--- a/gateway-messages/tests/versioning/v04.rs
+++ b/gateway-messages/tests/versioning/v04.rs
@@ -12,9 +12,7 @@
 //! can be removed as we will stop supporting v4.
 
 use super::assert_serialized;
-use gateway_messages::MgsRequest;
 use gateway_messages::RotError;
-use gateway_messages::SerializedSize;
 use gateway_messages::SpError;
 use gateway_messages::SpResponse;
 use gateway_messages::SpiError;
@@ -25,8 +23,6 @@ use gateway_messages::UpdateError;
 // Test SprotProtocolError
 #[test]
 fn sprot_errors() {
-    let mut out = [0; MgsRequest::MAX_SIZE];
-
     for (error, serialized) in [
         (SprotProtocolError::InvalidCrc, &[0_u8] as &[_]),
         (SprotProtocolError::FlowError, &[1]),
@@ -50,21 +46,19 @@ fn sprot_errors() {
         let response = SpResponse::Error(SpError::Sprot(error));
         let mut expected = vec![17, 29];
         expected.extend_from_slice(serialized);
-        assert_serialized(&mut out, &expected, &response);
+        assert_serialized(&expected, &response);
 
         // Test RotError variants
         let response = RotError::Sprot(error);
         let mut expected = vec![1];
         expected.extend_from_slice(serialized);
-        assert_serialized(&mut out, &expected, &response);
+        assert_serialized(&expected, &response);
     }
 }
 
 // Test SpiError
 #[test]
 fn spi_error() {
-    let mut out = [0; MgsRequest::MAX_SIZE];
-
     for (error, serialized) in [
         (SpiError::BadTransferSize, &[0_u8] as &[_]),
         (SpiError::TaskRestarted, &[1]),
@@ -80,21 +74,19 @@ fn spi_error() {
         let response = SpResponse::Error(SpError::Spi(error));
         let mut expected = vec![17, 30];
         expected.extend_from_slice(serialized);
-        assert_serialized(&mut out, &expected, &response);
+        assert_serialized(&expected, &response);
 
         // Test RotError variants
         let response = RotError::Spi(error);
         let mut expected = vec![2];
         expected.extend_from_slice(serialized);
-        assert_serialized(&mut out, &expected, &response);
+        assert_serialized(&expected, &response);
     }
 }
 
 // Test SprocketsError
 #[test]
 fn sprockets_error() {
-    let mut out = [0; MgsRequest::MAX_SIZE];
-
     for (error, serialized) in [
         (SprocketsError::BadEncoding, &[0_u8] as &[_]),
         (SprocketsError::UnsupportedVersion, &[1]),
@@ -108,21 +100,19 @@ fn sprockets_error() {
         let response = SpResponse::Error(SpError::Sprockets(error));
         let mut expected = vec![17, 31];
         expected.extend_from_slice(serialized);
-        assert_serialized(&mut out, &expected, &response);
+        assert_serialized(&expected, &response);
 
         // Test RotError variants
         let response = RotError::Sprockets(error);
         let mut expected = vec![3];
         expected.extend_from_slice(serialized);
-        assert_serialized(&mut out, &expected, &response);
+        assert_serialized(&expected, &response);
     }
 }
 
 // Test UpdateError
 #[test]
 fn update_error() {
-    let mut out = [0; MgsRequest::MAX_SIZE];
-
     for (error, serialized) in [
         (UpdateError::BadLength, &[0_u8] as &[_]),
         (UpdateError::UpdateInProgress, &[1]),
@@ -159,12 +149,12 @@ fn update_error() {
         let response = SpResponse::Error(SpError::Update(error));
         let mut expected = vec![17, 32];
         expected.extend_from_slice(serialized);
-        assert_serialized(&mut out, &expected, &response);
+        assert_serialized(&expected, &response);
 
         // Test RotError variants
         let response = RotError::Update(error);
         let mut expected = vec![4];
         expected.extend_from_slice(serialized);
-        assert_serialized(&mut out, &expected, &response);
+        assert_serialized(&expected, &response);
     }
 }

--- a/gateway-messages/tests/versioning/v05.rs
+++ b/gateway-messages/tests/versioning/v05.rs
@@ -13,13 +13,10 @@
 
 use super::assert_serialized;
 use gateway_messages::MgsRequest;
-use gateway_messages::SerializedSize;
 use gateway_messages::SpComponent;
 
 #[test]
 fn mgs_request() {
-    let mut out = [0; MgsRequest::MAX_SIZE];
-
     let request = MgsRequest::ReadComponentCaboose {
         component: SpComponent::SP_ITSELF,
         slot: 1,
@@ -31,5 +28,5 @@ fn mgs_request() {
         1, 0, // slot
         1, 2, 3, 4,
     ];
-    assert_serialized(&mut out, expected, &request);
+    assert_serialized(expected, &request);
 }

--- a/gateway-messages/tests/versioning/v06.rs
+++ b/gateway-messages/tests/versioning/v06.rs
@@ -15,7 +15,6 @@ use super::assert_serialized;
 use gateway_messages::RotError;
 use gateway_messages::RotSlotId;
 use gateway_messages::RotStateV2;
-use gateway_messages::SerializedSize;
 use gateway_messages::SpError;
 use gateway_messages::SpResponse;
 use gateway_messages::SpStateV2;
@@ -23,8 +22,6 @@ use gateway_messages::UpdateError;
 
 #[test]
 fn sp_response() {
-    let mut out = [0; SpResponse::MAX_SIZE];
-
     let rot = RotStateV2 {
         active: RotSlotId::A,
         persistent_boot_preference: RotSlotId::A,
@@ -79,21 +76,19 @@ fn sp_response() {
         0,0,0,0,0,0,0,0,0,0,0,0, // slot_b_sha3_256_digest
     ];
 
-    assert_serialized(&mut out, &expected, &response);
+    assert_serialized(&expected, &response);
 }
 
 #[test]
 fn update_error() {
     // This variant was added in v6
-    let mut out = [0; SpResponse::MAX_SIZE];
     let response =
         SpResponse::Error(SpError::Update(UpdateError::MissingHandoffData));
     let expected = vec![17, 32, 26];
-    assert_serialized(&mut out, &expected, &response);
+    assert_serialized(&expected, &response);
 
     // Test RotError variants
-    let mut out = [0; RotError::MAX_SIZE];
     let response = RotError::Update(UpdateError::MissingHandoffData);
     let expected = vec![4, 26];
-    assert_serialized(&mut out, &expected, &response);
+    assert_serialized(&expected, &response);
 }

--- a/gateway-messages/tests/versioning/v07.rs
+++ b/gateway-messages/tests/versioning/v07.rs
@@ -13,7 +13,6 @@
 
 use super::assert_serialized;
 use gateway_messages::RotError;
-use gateway_messages::SerializedSize;
 use gateway_messages::SpResponse;
 use gateway_messages::SpiError;
 use gateway_messages::SprocketsError;
@@ -24,8 +23,6 @@ use gateway_messages::UpdateStatus;
 
 #[test]
 fn sp_response() {
-    let mut out = [0; SpResponse::MAX_SIZE];
-
     // The full set of nested error serialization was tested back in v4; we'll
     // just repeat a few of those here.
     for (rot_error, serialized) in [
@@ -56,6 +53,6 @@ fn sp_response() {
         ];
         expected.extend_from_slice(&update_id);
         expected.extend_from_slice(serialized);
-        assert_serialized(&mut out, &expected, &response);
+        assert_serialized(&expected, &response);
     }
 }

--- a/gateway-messages/tests/versioning/v08.rs
+++ b/gateway-messages/tests/versioning/v08.rs
@@ -18,12 +18,10 @@ use gateway_messages::SensorReading;
 use gateway_messages::SensorRequest;
 use gateway_messages::SensorRequestKind;
 use gateway_messages::SensorResponse;
-use gateway_messages::SerializedSize;
 use gateway_messages::SpResponse;
 
 #[test]
 fn sp_response() {
-    let mut out = [0; SpResponse::MAX_SIZE];
     for (response, serialized) in [
         (
             SensorResponse::LastReading(SensorReading {
@@ -50,17 +48,16 @@ fn sp_response() {
             38, // SpResponse::ReadSensor
         ];
         expected.extend_from_slice(serialized);
-        assert_serialized(&mut out, &expected, &response);
+        assert_serialized(&expected, &response);
     }
 
     let response = SpResponse::CurrentTime(0x1234);
     let expected = [39, 0x34, 0x12, 0, 0, 0, 0, 0, 0];
-    assert_serialized(&mut out, &expected, &response);
+    assert_serialized(&expected, &response);
 }
 
 #[test]
 fn host_request() {
-    let mut out = [0; MgsRequest::MAX_SIZE];
     for (kind, serialized) in [
         (SensorRequestKind::LastReading, &[0, 0x34, 0x12, 0, 0]),
         (SensorRequestKind::LastData, &[1, 0x34, 0x12, 0, 0]),
@@ -73,23 +70,21 @@ fn host_request() {
             38, // MgsRequest::ReadSensor
         ];
         expected.extend_from_slice(serialized);
-        assert_serialized(&mut out, &expected, &request);
+        assert_serialized(&expected, &request);
     }
 
     let request = MgsRequest::CurrentTime;
     let expected = vec![
         39, // MgsRequest::CurrentTime
     ];
-    assert_serialized(&mut out, &expected, &request);
+    assert_serialized(&expected, &request);
 }
 
 #[test]
 fn sensor_data_missing() {
-    let mut out = [0; SensorDataMissing::MAX_SIZE];
-
-    assert_serialized(&mut out, &[0], &SensorDataMissing::DeviceOff);
-    assert_serialized(&mut out, &[1], &SensorDataMissing::DeviceError);
-    assert_serialized(&mut out, &[2], &SensorDataMissing::DeviceNotPresent);
-    assert_serialized(&mut out, &[3], &SensorDataMissing::DeviceUnavailable);
-    assert_serialized(&mut out, &[4], &SensorDataMissing::DeviceTimeout);
+    assert_serialized(&[0], &SensorDataMissing::DeviceOff);
+    assert_serialized(&[1], &SensorDataMissing::DeviceError);
+    assert_serialized(&[2], &SensorDataMissing::DeviceNotPresent);
+    assert_serialized(&[3], &SensorDataMissing::DeviceUnavailable);
+    assert_serialized(&[4], &SensorDataMissing::DeviceTimeout);
 }

--- a/gateway-messages/tests/versioning/v09.rs
+++ b/gateway-messages/tests/versioning/v09.rs
@@ -12,9 +12,7 @@
 //! can be removed as we will stop supporting v9.
 
 use super::assert_serialized;
-use gateway_messages::MgsRequest;
 use gateway_messages::RotError;
-use gateway_messages::SerializedSize;
 use gateway_messages::SpError;
 use gateway_messages::SpResponse;
 use gateway_messages::SprotProtocolError;
@@ -22,8 +20,6 @@ use gateway_messages::SprotProtocolError;
 // Test SprotProtocolError
 #[test]
 fn sprot_protocol_errors() {
-    let mut out = [0; MgsRequest::MAX_SIZE];
-
     for (error, serialized) in [
         (SprotProtocolError::InvalidCrc, &[0_u8] as &[_]),
         (SprotProtocolError::FlowError, &[1]),
@@ -48,12 +44,12 @@ fn sprot_protocol_errors() {
         let response = SpResponse::Error(SpError::Sprot(error));
         let mut expected = vec![17, 29];
         expected.extend_from_slice(serialized);
-        assert_serialized(&mut out, &expected, &response);
+        assert_serialized(&expected, &response);
 
         // Test RotError variants
         let response = RotError::Sprot(error);
         let mut expected = vec![1];
         expected.extend_from_slice(serialized);
-        assert_serialized(&mut out, &expected, &response);
+        assert_serialized(&expected, &response);
     }
 }

--- a/gateway-messages/tests/versioning/v10.rs
+++ b/gateway-messages/tests/versioning/v10.rs
@@ -16,20 +16,17 @@ use gateway_messages::CfpaPage;
 use gateway_messages::MgsRequest;
 use gateway_messages::RotRequest;
 use gateway_messages::RotResponse;
-use gateway_messages::SerializedSize;
 use gateway_messages::SpResponse;
 
 #[test]
 fn sp_response() {
-    let mut out = [0; SpResponse::MAX_SIZE];
     let response = SpResponse::ReadRot(RotResponse::Ok);
     let expected = [40, 0];
-    assert_serialized(&mut out, &expected, &response);
+    assert_serialized(&expected, &response);
 }
 
 #[test]
 fn host_request() {
-    let mut out = [0; MgsRequest::MAX_SIZE];
     for (r, serialized) in [
         (RotRequest::ReadCmpa, &[0u8] as &[_]),
         (RotRequest::ReadCfpa(CfpaPage::Active), &[1, 0]),
@@ -39,15 +36,13 @@ fn host_request() {
             40, // MgsRequest::ReadRot
         ];
         expected.extend_from_slice(serialized);
-        assert_serialized(&mut out, &expected, &request);
+        assert_serialized(&expected, &request);
     }
 }
 
 #[test]
 fn cfpa_page() {
-    let mut out = [0; CfpaPage::MAX_SIZE];
-
-    assert_serialized(&mut out, &[0], &CfpaPage::Active);
-    assert_serialized(&mut out, &[1], &CfpaPage::Inactive);
-    assert_serialized(&mut out, &[2], &CfpaPage::Scratch);
+    assert_serialized(&[0], &CfpaPage::Active);
+    assert_serialized(&[1], &CfpaPage::Inactive);
+    assert_serialized(&[2], &CfpaPage::Scratch);
 }

--- a/gateway-messages/tests/versioning/v11.rs
+++ b/gateway-messages/tests/versioning/v11.rs
@@ -13,31 +13,26 @@
 
 use super::assert_serialized;
 use gateway_messages::MgsRequest;
-use gateway_messages::SerializedSize;
 use gateway_messages::SpError;
 use gateway_messages::SpResponse;
 use gateway_messages::VpdError;
 
 #[test]
 fn sp_response() {
-    let mut out = [0; SpResponse::MAX_SIZE];
     let response = SpResponse::VpdLockState;
     let expected = [41];
-    assert_serialized(&mut out, &expected, &response);
+    assert_serialized(&expected, &response);
 }
 
 #[test]
 fn host_request() {
-    let mut out = [0; MgsRequest::MAX_SIZE];
     let request = MgsRequest::VpdLockState;
     let expected = [41];
-    assert_serialized(&mut out, &expected, &request);
+    assert_serialized(&expected, &request);
 }
 
 #[test]
 fn vpd_protocol_errors() {
-    let mut out = [0; SpResponse::MAX_SIZE];
-
     for (error, serialized) in [
         (VpdError::InvalidDevice, &[0]),
         (VpdError::NotPresent, &[1]),
@@ -60,6 +55,6 @@ fn vpd_protocol_errors() {
         let response = SpResponse::Error(SpError::Vpd(error));
         let mut expected = vec![17, 34];
         expected.extend_from_slice(serialized);
-        assert_serialized(&mut out, &expected, &response);
+        assert_serialized(&expected, &response);
     }
 }

--- a/gateway-messages/tests/versioning/v12.rs
+++ b/gateway-messages/tests/versioning/v12.rs
@@ -14,7 +14,6 @@
 use super::assert_serialized;
 use gateway_messages::MgsRequest;
 use gateway_messages::RotWatchdogError;
-use gateway_messages::SerializedSize;
 use gateway_messages::SpComponent;
 use gateway_messages::SpError;
 use gateway_messages::SpResponse;
@@ -22,20 +21,17 @@ use gateway_messages::WatchdogError;
 
 #[test]
 fn sp_response() {
-    let mut out = [0; SpResponse::MAX_SIZE];
-
     let response = SpResponse::DisableComponentWatchdogAck;
     let expected = [42];
-    assert_serialized(&mut out, &expected, &response);
+    assert_serialized(&expected, &response);
 
     let response = SpResponse::ComponentWatchdogSupportedAck;
     let expected = [43];
-    assert_serialized(&mut out, &expected, &response);
+    assert_serialized(&expected, &response);
 }
 
 #[test]
 fn host_request() {
-    let mut out = [0; MgsRequest::MAX_SIZE];
     let request = MgsRequest::ResetComponentTriggerWithWatchdog {
         component: SpComponent::SP_ITSELF,
         time_ms: 0x12345,
@@ -45,7 +41,7 @@ fn host_request() {
         b's', b'p', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // component
         0x45, 0x23, 0x01, 0x00, // time_ms
     ];
-    assert_serialized(&mut out, &expected, &request);
+    assert_serialized(&expected, &request);
 
     let request = MgsRequest::DisableComponentWatchdog {
         component: SpComponent::SP_ITSELF,
@@ -54,7 +50,7 @@ fn host_request() {
         43, // tag
         b's', b'p', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ];
-    assert_serialized(&mut out, &expected, &request);
+    assert_serialized(&expected, &request);
 
     let request = MgsRequest::ComponentWatchdogSupported {
         component: SpComponent::SP_ITSELF,
@@ -63,13 +59,11 @@ fn host_request() {
         44, // tag
         b's', b'p', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ];
-    assert_serialized(&mut out, &expected, &request);
+    assert_serialized(&expected, &request);
 }
 
 #[test]
 fn watchdog_error() {
-    let mut out = [0; SpResponse::MAX_SIZE];
-
     for err in [
         WatchdogError::NoCompletedUpdate,
         WatchdogError::Rot(RotWatchdogError::DongleDetected),
@@ -86,6 +80,6 @@ fn watchdog_error() {
             }
         };
         let response = SpResponse::Error(SpError::Watchdog(err));
-        assert_serialized(&mut out, serialized, &response);
+        assert_serialized(serialized, &response);
     }
 }

--- a/gateway-messages/tests/versioning/v13.rs
+++ b/gateway-messages/tests/versioning/v13.rs
@@ -22,14 +22,12 @@ use gateway_messages::MgsRequest;
 use gateway_messages::RotBootInfo;
 use gateway_messages::RotSlotId;
 use gateway_messages::RotStateV3;
-use gateway_messages::SerializedSize;
 use gateway_messages::SpResponse;
 use gateway_messages::SpStateV3;
 use gateway_messages::UpdateError;
 
 #[test]
 fn sp_response() {
-    let mut out = [0; SpResponse::MAX_SIZE];
     let response = SpResponse::SpStateV3(SpStateV3 {
         hubris_archive_id: [1, 2, 3, 4, 5, 6, 7, 8],
         serial_number: [
@@ -63,12 +61,11 @@ fn sp_response() {
         0, // power_state
     ];
 
-    assert_serialized(&mut out, &expected, &response);
+    assert_serialized(&expected, &response);
 }
 
 #[test]
 fn host_request() {
-    let mut out = [0; MgsRequest::MAX_SIZE];
     let request = MgsRequest::VersionedRotBootInfo { version: 3 };
 
     #[rustfmt::skip]
@@ -77,13 +74,11 @@ fn host_request() {
         3, // version
     ];
 
-    assert_serialized(&mut out, &expected, &request);
+    assert_serialized(&expected, &request);
 }
 
 #[test]
 fn rot_boot_info_v3() {
-    let mut out = [0; SpResponse::MAX_SIZE];
-
     let response = SpResponse::RotBootInfo(RotBootInfo::V3(RotStateV3 {
         active: RotSlotId::A,
         persistent_boot_preference: RotSlotId::A,
@@ -124,13 +119,11 @@ fn rot_boot_info_v3() {
         1, 1 // stage0next_status: Err(ImageError::FirstPageErased)
     ];
 
-    assert_serialized(&mut out, &expected, &response);
+    assert_serialized(&expected, &response);
 }
 
 #[test]
 fn error_enums() {
-    let mut out = [0; SpResponse::MAX_SIZE];
-
     let response: [ImageError; 13] = [
         ImageError::Unchecked,
         ImageError::FirstPageErased,
@@ -147,7 +140,7 @@ fn error_enums() {
         ImageError::Signature,
     ];
     let expected = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-    assert_serialized(&mut out, &expected, &response);
+    assert_serialized(&expected, &response);
 
     let response: [UpdateError; 3] = [
         UpdateError::BlockOutOfOrder,
@@ -155,5 +148,5 @@ fn error_enums() {
         UpdateError::InvalidSlotIdForOperation,
     ];
     let expected = vec![27, 28, 29];
-    assert_serialized(&mut out, &expected, &response);
+    assert_serialized(&expected, &response);
 }

--- a/gateway-messages/tests/versioning/v14.rs
+++ b/gateway-messages/tests/versioning/v14.rs
@@ -21,7 +21,6 @@ use gateway_messages::ComponentActionResponse;
 use gateway_messages::MonorailComponentAction;
 use gateway_messages::MonorailComponentActionResponse;
 use gateway_messages::MonorailError;
-use gateway_messages::SerializedSize;
 use gateway_messages::SpError;
 use gateway_messages::SpResponse;
 use gateway_messages::UnlockChallenge;
@@ -29,14 +28,13 @@ use gateway_messages::UnlockResponse;
 
 #[test]
 fn monorail_component_action() {
-    let mut out = [0; ComponentAction::MAX_SIZE];
     let action =
         ComponentAction::Monorail(MonorailComponentAction::RequestChallenge);
     let expected = vec![
         1, // Monorail
         0, // RequestChallenge
     ];
-    assert_serialized(&mut out, &expected, &action);
+    assert_serialized(&expected, &action);
 
     let action = ComponentAction::Monorail(MonorailComponentAction::Unlock {
         challenge: UnlockChallenge::Trivial { timestamp: 0x1234 },
@@ -52,25 +50,23 @@ fn monorail_component_action() {
         0x67, 0x45, 0, 0, 0, 0, 0, 0, // timestamp
         0x34, 0x12, 0, 0, // time_s
     ];
-    assert_serialized(&mut out, &expected, &action);
+    assert_serialized(&expected, &action);
 
     let action = ComponentAction::Monorail(MonorailComponentAction::Lock);
     let expected = vec![
         1, // Monorail
         2, // Lock
     ];
-    assert_serialized(&mut out, &expected, &action);
+    assert_serialized(&expected, &action);
 }
 #[test]
 fn component_action_response() {
-    let mut out = [0; SpResponse::MAX_SIZE];
-
     let r = SpResponse::ComponentAction(ComponentActionResponse::Ack);
     let expected = vec![
         46, // ComponentAction
         0,  // Ack
     ];
-    assert_serialized(&mut out, &expected, &r);
+    assert_serialized(&expected, &r);
 
     let r = SpResponse::ComponentAction(ComponentActionResponse::Monorail(
         MonorailComponentActionResponse::RequestChallenge(
@@ -84,13 +80,11 @@ fn component_action_response() {
         0,  // Trivial
         0x55, 0x44, 0, 0, 0, 0, 0, 0, // timestamp
     ];
-    assert_serialized(&mut out, &expected, &r);
+    assert_serialized(&expected, &r);
 }
 
 #[test]
 fn monorail_error() {
-    let mut out = [0; ComponentAction::MAX_SIZE];
-
     for (i, e) in [
         MonorailError::UnlockAuthFailed,
         MonorailError::UnlockFailed,
@@ -111,6 +105,6 @@ fn monorail_error() {
             36,      // Monorail
             i as u8, // error code
         ];
-        assert_serialized(&mut out, &expected, &err);
+        assert_serialized(&expected, &err);
     }
 }

--- a/gateway-messages/tests/versioning/v15.rs
+++ b/gateway-messages/tests/versioning/v15.rs
@@ -21,15 +21,12 @@ use gateway_messages::ComponentActionResponse;
 use gateway_messages::EcdsaSha2Nistp256Challenge;
 use gateway_messages::MonorailComponentAction;
 use gateway_messages::MonorailComponentActionResponse;
-use gateway_messages::SerializedSize;
 use gateway_messages::SpResponse;
 use gateway_messages::UnlockChallenge;
 use gateway_messages::UnlockResponse;
 
 #[test]
 fn monorail_component_action() {
-    let mut out = [0; ComponentAction::MAX_SIZE];
-
     #[rustfmt::skip]
     let action = ComponentAction::Monorail(MonorailComponentAction::Unlock {
         challenge: UnlockChallenge::EcdsaSha2Nistp256(
@@ -117,12 +114,10 @@ fn monorail_component_action() {
 
         0x34, 0x12, 0, 0, // time_s
     ];
-    assert_serialized(&mut out, &expected, &action);
+    assert_serialized(&expected, &action);
 }
 #[test]
 fn component_action_response() {
-    let mut out = [0; SpResponse::MAX_SIZE];
-
     #[rustfmt::skip]
     let r = SpResponse::ComponentAction(ComponentActionResponse::Monorail(
         MonorailComponentActionResponse::RequestChallenge(
@@ -163,5 +158,5 @@ fn component_action_response() {
         1, 2, 3, 4, 5, 6, 7, 8,
         1, 2, 3, 4, 5, 6, 7, 8,
     ];
-    assert_serialized(&mut out, &expected, &r);
+    assert_serialized(&expected, &r);
 }

--- a/gateway-messages/tests/versioning/v16.rs
+++ b/gateway-messages/tests/versioning/v16.rs
@@ -17,13 +17,9 @@
 
 use super::assert_serialized;
 use gateway_messages::measurement::MeasurementKind;
-use gateway_messages::SerializedSize;
-use gateway_messages::SpResponse;
 
 #[test]
 fn measurement_kinds() {
-    let mut out = [0; SpResponse::MAX_SIZE];
-
     for (kind, serialized) in [
         (MeasurementKind::Temperature, &[0]),
         (MeasurementKind::Power, &[1]),
@@ -34,6 +30,6 @@ fn measurement_kinds() {
         (MeasurementKind::Speed, &[6]),
         (MeasurementKind::CpuTctl, &[7]),
     ] {
-        assert_serialized(&mut out, serialized, &kind);
+        assert_serialized(serialized, &kind);
     }
 }


### PR DESCRIPTION
This adds one more allocation (because we can't use the generic parameter, `error: constant expression depends on a generic parameter`), but it makes a bunch of other code less verbose.