### PR TITLE
Updates: recover from `InvalidUpdateChunk`

### DIFF
--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -984,7 +984,7 @@ pub enum SpError {
     /// Received an invalid update chunk; the SP was expecting an update chunk
     /// with a different offset.
     ///
-    /// This error may indicate packet less from the SP to MGS (e.g., MGS will
+    /// This error may indicate packet loss from the SP to MGS (e.g., MGS will
     /// resend an already-received-by-the-SP update chunk if it missed an ACK).
     /// This error should be recoverable by asking the SP for its update status
     /// to determine which chunk it wants and resuming from there. MGS and

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -981,8 +981,15 @@ pub enum SpError {
     /// An update is already in progress with the specified amount of data
     /// already provided. MGS should resume the update at that offset.
     UpdateInProgress(UpdateStatus),
-    /// Received an invalid update chunk; the in-progress update must be
-    /// aborted and restarted.
+    /// Received an invalid update chunk; the SP was expecting an update chunk
+    /// with a different offset.
+    ///
+    /// This error may indicate packet less from the SP to MGS (e.g., MGS will
+    /// resend an already-received-by-the-SP update chunk if it missed an ACK).
+    /// This error should be recoverable by asking the SP for its update status
+    /// to determine which chunk it wants and resuming from there. MGS and
+    /// faux-mgs attempt this automatically, so this error should only bubble
+    /// out to users if that recovery process has failed.
     InvalidUpdateChunk,
     /// An update operation failed with the associated code.
     UpdateFailed(u32),

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -91,6 +91,9 @@ use self::update::start_rot_update;
 use self::update::start_sp_update;
 use self::update::update_status;
 
+pub use self::update::UpdateDriverTask;
+pub use self::update::UpdateDriverTaskError;
+
 // Once we've discovered an SP, continue to send discovery packets on this
 // interval to detect changes.
 //
@@ -721,7 +724,7 @@ impl SingleSp {
         update_id: Uuid,
         slot: u16,
         image: Vec<u8>,
-    ) -> Result<(), UpdateError> {
+    ) -> Result<UpdateDriverTask, UpdateError> {
         if image.is_empty() {
             return Err(UpdateError::ImageEmpty);
         }


### PR DESCRIPTION
If we get an `InvalidUpdateChunk` while delivering updates, attempt to recover by asking the SP for its update status and resuming from the offset it wants (assuming it's still expecting the update we're trying to deliver!).

Fixes #332. Builds on #333.