### PR TITLE
Update `zerocopy` to v0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,7 +756,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "uuid",
- "zerocopy 0.6.6",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -936,7 +936,7 @@ dependencies = [
  "static_assertions",
  "strum_macros",
  "uuid",
- "zerocopy 0.6.6",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -3655,6 +3655,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive 0.8.25",
+]
+
+[[package]]
 name = "zerocopy-derive"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3670,6 +3679,17 @@ name = "zerocopy-derive"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ tokio-util = { version = "0.7", features = ["compat"] }
 usdt = "0.5.0"
 uuid = { version = "1.16", default-features = false }
 version_check = "0.9.5"
-zerocopy = "0.6.6"
+zerocopy = "0.8.25"
 zip = { version = "0.6.6", default-features = false, features = ["deflate", "bzip2"] }
 
 gateway-messages.path = "gateway-messages"

--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -60,7 +60,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::UdpSocket;
 use uuid::Uuid;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 mod picocom_map;
 mod usart;

--- a/gateway-messages/Cargo.toml
+++ b/gateway-messages/Cargo.toml
@@ -14,7 +14,7 @@ smoltcp = { workspace = true, optional = true }
 static_assertions.workspace = true
 strum_macros.workspace = true
 uuid.workspace = true
-zerocopy.workspace = true
+zerocopy = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -343,7 +343,9 @@ pub enum UnlockChallenge {
     PartialEq,
     Eq,
     Debug,
-    zerocopy::AsBytes,
+    zerocopy::IntoBytes,
+    zerocopy::KnownLayout,
+    zerocopy::Immutable,
 )]
 #[repr(C)]
 pub struct EcdsaSha2Nistp256Challenge {


### PR DESCRIPTION
This branch updates our `zerocopy` dependency from v0.6.x to v0.8.x. I initially made the upgrade as I wanted to use some new `zerocopy` features in #370, but have factored it out to land separately. Of course, we'll need to update Hubris and MGS, as well.

Note that `zerocopy`'s `read_from_prefix` now returns the rest of the buffer, making some code a little bit simpler where we were previously doing that manually. Other than that, there's not a lot to this change, besides deriving some additional marker traits (`Immutable` and `KnownLayout`).