### PR TITLE
Add --transient flag to component-active-slot

### DIFF
--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -8,7 +8,6 @@ use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
-use clap::CommandFactory;
 use clap::Parser;
 use clap::Subcommand;
 use clap::ValueEnum;
@@ -1149,12 +1148,7 @@ async fn run_command(
         }
         Command::ComponentActiveSlot { component, set, persist, transient } => {
             if transient && component != SpComponent::ROT {
-                let cmd = Args::command();
-                clap::Error::raw( clap::error::ErrorKind::ArgumentConflict,
-                    format!(
-                        "The --transient (-t) flag is only allowed for the 'rot' component, not for {}\n", component
-                        )
-                    ).with_cmd(&cmd).exit();
+                bail!("The --transient (-t) flag is only allowed for the 'rot' component, not for {component}");
             } else if let Some(slot) = set {
                 sp.set_component_active_slot(component, slot, persist).await?;
                 if json {
@@ -1324,7 +1318,7 @@ async fn run_command(
                     ..
                 } => {
                     let id = Uuid::from(id);
-                    format!("update {id} aux flash scan complete (found_match={found_match}")
+                    format!("update {id} aux flash scan complete (found_match={found_match})")
                 }
                 UpdateStatus::InProgress(sub_status) => {
                     let id = Uuid::from(sub_status.id);


### PR DESCRIPTION
When setting a RoT Hubris bank as persistent or transient either the -t or -p flag must be used in conjunction with the -s flag.

```
Get or set the active slot of a component (e.g., `host-boot-flash`).

Except for component "stage0", setting the active slot can be viewed as an atomic operation.

Setting "stage0" slot 1 as the active slot initiates a copy from slot 1 to slot 0 if the contents of
slot 1 still match those seen at last RoT reset and the contents are properly signed.

Power failures during the copy can disable the RoT. Only one stage0 update should be in process in a
rack at any time.

Usage: faux-mgs --interface <INTERFACE> component-active-slot [OPTIONS] <COMPONENT>

Arguments:
  <COMPONENT>

Options:
  -s, --set <SLOT>
          set the active slot

  -p, --persist
          persist the active slot to non-volatile memory

  -t, --transient
          Only valid with component "rot": Prefer the specified slot on the next soft reset

  -h, --help
          Print help (see a summary with '-h')
```

Test runs:
```
Run #1: cargo -q run -- -l crit --interface enp5s0 component-active-slot            rot
1
Run #2: cargo -q run -- -l crit --interface enp5s0 component-active-slot         -t rot
error: the following required arguments were not provided:
  --set <SLOT>

Usage: faux-mgs --interface <INTERFACE> component-active-slot --set <SLOT> <--persist|--transient> <COMPONENT>

For more information, try '--help'.
Run #3: cargo -q run -- -l crit --interface enp5s0 component-active-slot      -p    rot
error: the following required arguments were not provided:
  --set <SLOT>

Usage: faux-mgs --interface <INTERFACE> component-active-slot --set <SLOT> <--persist|--transient> <COMPONENT>

For more information, try '--help'.
Run #4: cargo -q run -- -l crit --interface enp5s0 component-active-slot      -p -p rot
error: the argument '--persist' cannot be used multiple times

Usage: faux-mgs --interface <INTERFACE> component-active-slot [OPTIONS] <COMPONENT>

For more information, try '--help'.
Run #5: cargo -q run -- -l crit --interface enp5s0 component-active-slot      -p -t rot
error: the argument '--persist' cannot be used with '--transient'

Usage: faux-mgs --interface <INTERFACE> component-active-slot --set <SLOT> --persist <COMPONENT>

For more information, try '--help'.
Run #6: cargo -q run -- -l crit --interface enp5s0 component-active-slot      -t -t rot
error: the argument '--transient' cannot be used multiple times

Usage: faux-mgs --interface <INTERFACE> component-active-slot [OPTIONS] <COMPONENT>

For more information, try '--help'.
Run #7: cargo -q run -- -l crit --interface enp5s0 component-active-slot -s 0       rot
error: the following required arguments were not provided:
  <--persist|--transient>

Usage: faux-mgs --interface <INTERFACE> component-active-slot --set <SLOT> <--persist|--transient> <COMPONENT>

For more information, try '--help'.
Run #8: cargo -q run -- -l crit --interface enp5s0 component-active-slot -s 0    -t rot
set active slot for SpComponent { id: "rot" } to 0
Run #9: cargo -q run -- -l crit --interface enp5s0 component-active-slot -s 0 -p    rot
set active slot for SpComponent { id: "rot" } to 0
Run #10: cargo -q run -- -l crit --interface enp5s0 component-active-slot -s 0 -p -p rot
error: the argument '--persist' cannot be used multiple times

Usage: faux-mgs --interface <INTERFACE> component-active-slot [OPTIONS] <COMPONENT>

For more information, try '--help'.
Run #11: cargo -q run -- -l crit --interface enp5s0 component-active-slot -s 0 -p -t rot
error: the argument '--persist' cannot be used with '--transient'

Usage: faux-mgs --interface <INTERFACE> component-active-slot --set <SLOT> <--persist|--transient> <COMPONENT>

For more information, try '--help'.
Run #12: cargo -q run -- -l crit --interface enp5s0 component-active-slot -s 0 -t -t rot
error: the argument '--transient' cannot be used multiple times

Usage: faux-mgs --interface <INTERFACE> component-active-slot [OPTIONS] <COMPONENT>

For more information, try '--help'.
Run #13: cargo -q run -- -l crit --interface enp5s0 component-active-slot -s 0    -t sp
error: The --transient (-t) flag is only allowed for the 'rot' component, not for sp
Run #14: cargo -q run -- -l crit --interface enp5s0 component-active-slot -s 0 -p    sp
set active slot for SpComponent { id: "sp" } to 0
Run #15: cargo -q run -- -l crit --interface enp5s0 component-active-slot -s 0 -p -p sp
error: the argument '--persist' cannot be used multiple times

Usage: faux-mgs --interface <INTERFACE> component-active-slot [OPTIONS] <COMPONENT>

For more information, try '--help'.
Run #16: cargo -q run -- -l crit --interface enp5s0 component-active-slot -s 0 -t -t sp
error: the argument '--transient' cannot be used multiple times

Usage: faux-mgs --interface <INTERFACE> component-active-slot [OPTIONS] <COMPONENT>

For more information, try '--help'.
```