### PR TITLE
ereport-messages: Remove COMMIT flag from requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,8 +932,7 @@ dependencies = [
 name = "gateway-ereport-messages"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.9.0",
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -988,7 +987,7 @@ dependencies = [
  "usdt",
  "uuid",
  "version_check",
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
  "zip",
 ]
 

--- a/gateway-ereport-messages/Cargo.toml
+++ b/gateway-ereport-messages/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-bitflags.workspace = true
 zerocopy = { workspace = true, features = ["derive"] }
 
 [features]

--- a/gateway-sp-comms/src/ereport.rs
+++ b/gateway-sp-comms/src/ereport.rs
@@ -1123,7 +1123,7 @@ mod test {
 
         let header = ResponseHeader::V0(ResponseHeaderV0 {
             restart_id: restart_id.as_u128().into(),
-            start_ena: Ena::ZERO,
+            start_ena: Ena::NONE,
             request_id,
         });
 
@@ -1205,7 +1205,7 @@ mod test {
 
         assert_ereport_matches(
             &ereports[0],
-            Ena::ZERO,
+            Ena::NONE,
             json_map! {
                 KEY_ARCHIVE: "defaceddead".to_string(),
                 KEY_SERIAL: "BRM69000666".to_string(),


### PR DESCRIPTION
As discussed in [this comment][1] from @cbiffle, the `C`/`COMMIT` flag in ereport request messages is unnecessary, as ENA 0 is reserved by the SP to indicate "no ENA". So, if we want to say "no ENAs have been committed", MGS can just send ENA 0. This makes the request message an entire byte smaller (wow! whoa!), and also lets us remove the dependency on the `bitflags` crate, which in turn means less code in `packrat`.

I've changed the name of the `Ena::ZERO` constant to `Ena::NONE` to communicate that ENA 0 means "no ENA".

[1]: https://github.com/oxidecomputer/rfd/pull/888/files/7146ee385715d1ddc6b7dc2462df7da80ec3bde7#r2078301646