### PR TITLE
Make no-op `SetPowerState` calls a success

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,7 +933,7 @@ name = "gateway-ereport-messages"
 version = "0.1.0"
 dependencies = [
  "bitflags 2.9.0",
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -988,7 +988,7 @@ dependencies = [
  "usdt",
  "uuid",
  "version_check",
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
  "zip",
 ]
 

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -66,7 +66,7 @@ pub const ROT_PAGE_SIZE: usize = 512;
 /// for more detail and discussion.
 pub mod version {
     pub const MIN: u32 = 2;
-    pub const CURRENT: u32 = 17;
+    pub const CURRENT: u32 = 18;
 
     /// MGS protocol version in which SP watchdog messages were added
     pub const WATCHDOG_VERSION: u32 = 12;

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -958,7 +958,7 @@ pub struct UpdateInProgressStatus {
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
 pub enum PowerStateTransition {
-    Changed = 1,
+    Changed,
     Unchanged,
 }
 

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -92,6 +92,12 @@ pub enum SpResponse {
     ///
     /// If the SP is already in the desired power state, the
     /// [`Self::PowerStateUnchanged`] response is returned instead.
+    ///
+    /// **Note**: Prior to v18, this message was named `SetPowerStateAck`, but
+    /// it was only sent when a power state change occurred (so its semantic
+    /// meaning has remained the same). In v17 and earlier, a
+    /// [`SpError::SeqError`] message was sent in the case where no power state
+    /// transition occurred, instead of a `PowerStateUnchanged` message.
     PowerStateSet,
     ResetPrepareAck,
     // There is intentionally no `ResetTriggerAck` response; the expected
@@ -956,7 +962,6 @@ pub struct UpdateInProgressStatus {
 /// Represents the result of a successful [`SetPowerState`] request.
 /// [`SetPowerState`]: crate::MgsRequest::SetPowerState
 #[derive(Copy, Clone, PartialEq, Eq)]
-#[repr(u8)]
 pub enum PowerStateTransition {
     Changed,
     Unchanged,

--- a/gateway-messages/tests/versioning/mod.rs
+++ b/gateway-messages/tests/versioning/mod.rs
@@ -23,6 +23,7 @@ mod v14;
 mod v15;
 mod v16;
 mod v17;
+mod v18;
 
 pub fn assert_serialized<T: Serialize + SerializedSize + std::fmt::Debug>(
     expected: &[u8],

--- a/gateway-messages/tests/versioning/v02.rs
+++ b/gateway-messages/tests/versioning/v02.rs
@@ -838,7 +838,7 @@ fn sp_response() {
         assert_serialized(expected, &response);
     }
 
-    let response = SpResponse::SetPowerStateAck;
+    let response = SpResponse::PowerStateSet;
     let expected = &[14];
     assert_serialized(expected, &response);
 

--- a/gateway-messages/tests/versioning/v18.rs
+++ b/gateway-messages/tests/versioning/v18.rs
@@ -21,6 +21,6 @@ use gateway_messages::SpResponse;
 #[test]
 fn sp_response() {
     let response = SpResponse::PowerStateUnchanged;
-    let expected = &[83];
+    let expected = &[48];
     assert_serialized(expected, &response);
 }

--- a/gateway-messages/tests/versioning/v18.rs
+++ b/gateway-messages/tests/versioning/v18.rs
@@ -20,7 +20,7 @@ use gateway_messages::SpResponse;
 
 #[test]
 fn sp_response() {
-    let response = SpResponse::PowerStateUnchaged;
+    let response = SpResponse::PowerStateUnchanged;
     let expected = &[83];
     assert_serialized(expected, &response);
 }

--- a/gateway-messages/tests/versioning/v18.rs
+++ b/gateway-messages/tests/versioning/v18.rs
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! This source file is named after the protocol version being tested,
+//! e.g. v01.rs implements tests for protocol version 1.
+//! The tested protocol version is represented by "$VERSION" below.
+//!
+//! The tests in this module check that the serialized form of messages from MGS
+//! protocol version $VERSION have not changed.
+//!
+//! If a test in this module fails, _do not change the test_! This means you
+//! have changed, deleted, or reordered an existing message type or enum
+//! variant, and you should revert that change. This will remain true until we
+//! bump the `version::MIN` to a value higher than $VERSION, at which point these
+//! tests can be removed as we will stop supporting $VERSION.
+
+use super::assert_serialized;
+use gateway_messages::SpResponse;
+
+#[test]
+fn sp_response() {
+    let response = SpResponse::PowerStateUnchaged;
+    let expected = &[83];
+    assert_serialized(expected, &response);
+}

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -43,6 +43,7 @@ use gateway_messages::MessageKind;
 use gateway_messages::MgsRequest;
 use gateway_messages::MonorailError;
 use gateway_messages::PowerState;
+use gateway_messages::PowerStateTransition;
 use gateway_messages::RotBootInfo;
 use gateway_messages::RotRequest;
 use gateway_messages::SensorReading;
@@ -822,10 +823,13 @@ impl SingleSp {
     }
 
     /// Set the current power state.
-    pub async fn set_power_state(&self, power_state: PowerState) -> Result<()> {
+    pub async fn set_power_state(
+        &self,
+        power_state: PowerState,
+    ) -> Result<PowerStateTransition> {
         self.rpc(MgsRequest::SetPowerState(power_state))
             .await
-            .and_then(expect_set_power_state_ack)
+            .and_then(expect_power_state_transition)
     }
 
     /// "Attach" to the serial console, setting up a tokio channel for all


### PR DESCRIPTION
Presently, the `SetPowerState` MGS request returns an `IllegalTransition` error when the system is already in the desired power state. This is generally not the desired behavior: the `IllegalTransition` error code represents both power state transitions that will *never* succeed, and cases where the SP was already in the desired power state and we didn't have to do anything (which is a success from the perspective of a maohority of callers). In the cases where this should be treated as an error, it's useful to be able to disambiguate between "you tried to request a transition that is never allowed" and "your request failed because it raced with another request", and in most other cases where callers just want to ensure that the system is in the desired power state, it should be treated as a success. See #270 for details.

This change modifies the gateway-SP protocol to allow the SP to communicate more accurately about no-op power state transitions. `SpHandler`'s `set_power_state` method now returns a `PowerStateTransition` type that indicates whether or not a change occurred, and the `SpResponse` message enum has grown a new `PowerStateUnchanged` variant. We now construct either that variant or the `PowerStateSet` variant (née `SetPowerStateAck`, it's okay to rename variants already in the protocol as it won't change their encoding on the wire) based on whether or not the handler actually indicates that a change occurred. In `gateway-sp-comms`, we then re-construct the `PowerStateTransition` enum fro mthe two possible `SpResposne` messages.

Encoding the no-op case as a new `SpResponse` message was chosen because it's the most backwards-compatible way to do this: in previous versions, the `SpResponse::SetPowerStateAck` message would only be sent if the state transitioned, and an error would be sent otherwise. Adding a new variant for the "no op" case preserves the semantics of the existing message. Alternatively, we could have added a new `SpResponse` variant that holds an additional enum or bool, and deprecate the `SetPowerStateAck` message, but that felt unfortunate, as it left behind a deprecated enum variant that would still need to be handled until it was eventually removed. Also, with two separate variants, we can encode both messages as a single byte instead of two.

On the SP side, oxidecomputer/hubris#2064 lays the groundwork for this by changing the sequencer IPC interface to also indicate no-op power state transitions from `IllegalTransition` errors. An additional change will be necessary to integrate that with the new `gateway-messages` messages in this branch, if the Hubris PR merges first.