### PR TITLE
Add `Debug` logging for  power state transitions

### DIFF
--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -961,7 +961,7 @@ pub struct UpdateInProgressStatus {
 
 /// Represents the result of a successful [`SetPowerState`] request.
 /// [`SetPowerState`]: crate::MgsRequest::SetPowerState
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum PowerStateTransition {
     Changed,
     Unchanged,


### PR DESCRIPTION
While working on integrating the changes from #390 in Omicron, I realized that I should really have added a `Debug` implementation for `PowerStateTransition`, so that MGS can log the outcome of a `set_power_state` request without having to have two separate log macro invocations in a branch. This commit adds `#[derive(Debug)]` to `PowerStateTransition` in service of that.

Furthermore, `faux-mgs` should probably indicate to the user whether a request to set the power state results in an actual change in state, so I've updated it to do that. Whether or not a transition occurred is now included in the `slog` logging, textual output, and JSON output from `faux-mgs`.