### PR TITLE
Add untested cases to v13

### DIFF
--- a/gateway-messages/tests/versioning/v13.rs
+++ b/gateway-messages/tests/versioning/v13.rs
@@ -142,11 +142,15 @@ fn error_enums() {
     let expected = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
     assert_serialized(&expected, &response);
 
-    let response: [UpdateError; 3] = [
+    let response: [UpdateError; 7] = [
         UpdateError::BlockOutOfOrder,
         UpdateError::InvalidComponent,
         UpdateError::InvalidSlotIdForOperation,
+        UpdateError::InvalidArchive,
+        UpdateError::ImageMismatch,
+        UpdateError::SignatureNotValidated,
+        UpdateError::VersionNotSupported,
     ];
-    let expected = vec![27, 28, 29];
+    let expected = vec![27, 28, 29, 30, 31, 32, 33];
     assert_serialized(&expected, &response);
 }


### PR DESCRIPTION
Commit c85a4ca043aaa389df12aac5348d8a3feda28762 added new errors in V13 of our communication protocol, but did not test them exhaustively.  This PR adds the missing tests to `tests/versioning/v13.rs`.