### PR TITLE
Revert "Add InvalidPreferredSlotId error for use in rot prep_image_update (#398)"

### DIFF
--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -1294,7 +1294,6 @@ pub enum UpdateError {
     ImageMismatch,
     SignatureNotValidated,
     VersionNotSupported,
-    InvalidPreferredSlotId,
 }
 
 impl fmt::Display for UpdateError {
@@ -1353,12 +1352,6 @@ impl fmt::Display for UpdateError {
             }
             Self::InvalidComponent => {
                 write!(f, "invalid component for operation")
-            }
-            Self::InvalidPreferredSlotId => {
-                write!(
-                    f,
-                    "updating a bootloader preferred slot is not permitted"
-                )
             }
         }
     }

--- a/gateway-messages/tests/versioning/v19.rs
+++ b/gateway-messages/tests/versioning/v19.rs
@@ -16,9 +16,6 @@
 //! tests can be removed as we will stop supporting $VERSION.
 
 use super::assert_serialized;
-use gateway_messages::ImageError;
-use gateway_messages::SpStateV3;
-use gateway_messages::UpdateError;
 use gateway_messages::{HfError, MgsRequest, SpError, SpResponse};
 
 #[test]
@@ -62,85 +59,4 @@ fn read_host_flash() {
         let request = SpError::Hf(e);
         assert_serialized(&[38, i as u8], &request);
     }
-}
-
-#[test]
-fn sp_response() {
-    let response = SpResponse::SpStateV3(SpStateV3 {
-        hubris_archive_id: [1, 2, 3, 4, 5, 6, 7, 8],
-        serial_number: [
-            9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
-            26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
-        ],
-        model: [
-            41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
-            58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72,
-        ],
-        revision: 0xf0f1f2f3,
-        base_mac_address: [73, 74, 75, 76, 77, 78],
-        power_state: gateway_messages::PowerState::A0,
-    });
-
-    #[rustfmt::skip]
-    let expected = vec![
-        44, // SpStateV3
-        1, 2, 3, 4, 5, 6, 7, 8, // hubris_archive_id
-
-        9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
-        24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
-        39, 40, // serial_number
-
-        41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
-        56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
-        71, 72, // model
-
-        0xf3, 0xf2, 0xf1, 0xf0, // revision
-        73, 74, 75, 76, 77, 78, // base_mac_address
-        0, // power_state
-    ];
-
-    assert_serialized(&expected, &response);
-}
-
-#[test]
-fn host_request() {
-    let request = MgsRequest::VersionedRotBootInfo { version: 3 };
-
-    #[rustfmt::skip]
-    let expected = vec![
-        45, // VersionedRotBootInfo
-        3, // version
-    ];
-
-    assert_serialized(&expected, &request);
-}
-
-#[test]
-fn error_enums() {
-    let response: [ImageError; 13] = [
-        ImageError::Unchecked,
-        ImageError::FirstPageErased,
-        ImageError::PartiallyProgrammed,
-        ImageError::InvalidLength,
-        ImageError::HeaderNotProgrammed,
-        ImageError::BootloaderTooSmall,
-        ImageError::BadMagic,
-        ImageError::HeaderImageSize,
-        ImageError::UnalignedLength,
-        ImageError::UnsupportedType,
-        ImageError::ResetVectorNotThumb2,
-        ImageError::ResetVector,
-        ImageError::Signature,
-    ];
-    let expected = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-    assert_serialized(&expected, &response);
-
-    let response: [UpdateError; 4] = [
-        UpdateError::BlockOutOfOrder,
-        UpdateError::InvalidComponent,
-        UpdateError::InvalidSlotIdForOperation,
-        UpdateError::InvalidPreferredSlotId,
-    ];
-    let expected = vec![27, 28, 29, 34];
-    assert_serialized(&expected, &response);
 }

--- a/gateway-sp-comms/src/error.rs
+++ b/gateway-sp-comms/src/error.rs
@@ -116,8 +116,6 @@ pub enum UpdateError {
     InvalidComponent,
     #[error("an image was not found")]
     ImageNotFound,
-    #[error("updating a bootloader preferred slot is not permitted")]
-    InvalidPreferredSlotId,
 }
 
 #[derive(Debug, thiserror::Error, SlogInlineError)]


### PR DESCRIPTION
This reverts commit 8cb4c31b4d0eeca5a024394d944a812fdc410b78.

(To address remaining open comments on #398)