### PR TITLE
Add InvalidPreferredSlotId error for use in rot prep_image_update

### DIFF
--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -69,7 +69,7 @@ pub const HF_PAGE_SIZE: usize = 256;
 /// for more detail and discussion.
 pub mod version {
     pub const MIN: u32 = 2;
-    pub const CURRENT: u32 = 19;
+    pub const CURRENT: u32 = 20;
 
     /// MGS protocol version in which SP watchdog messages were added
     pub const WATCHDOG_VERSION: u32 = 12;

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -1294,6 +1294,7 @@ pub enum UpdateError {
     ImageMismatch,
     SignatureNotValidated,
     VersionNotSupported,
+    InvalidPreferredSlotId,
 }
 
 impl fmt::Display for UpdateError {
@@ -1352,6 +1353,12 @@ impl fmt::Display for UpdateError {
             }
             Self::InvalidComponent => {
                 write!(f, "invalid component for operation")
+            }
+            Self::InvalidPreferredSlotId => {
+                write!(
+                    f,
+                    "updating a bootloader preferred slot is not permitted"
+                )
             }
         }
     }

--- a/gateway-messages/tests/versioning/mod.rs
+++ b/gateway-messages/tests/versioning/mod.rs
@@ -25,6 +25,7 @@ mod v16;
 mod v17;
 mod v18;
 mod v19;
+mod v20;
 
 pub fn assert_serialized<T: Serialize + SerializedSize + std::fmt::Debug>(
     expected: &[u8],

--- a/gateway-messages/tests/versioning/v20.rs
+++ b/gateway-messages/tests/versioning/v20.rs
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! This source file is named after the protocol version being tested,
+//! e.g. v01.rs implements tests for protocol version 1.
+//! The tested protocol version is represented by "$VERSION" below.
+//!
+//! The tests in this module check that the serialized form of messages from MGS
+//! protocol version $VERSION have not changed.
+//!
+//! If a test in this module fails, _do not change the test_! This means you
+//! have changed, deleted, or reordered an existing message type or enum
+//! variant, and you should revert that change. This will remain true until we
+//! bump the `version::MIN` to a value higher than $VERSION, at which point these
+//! tests can be removed as we will stop supporting $VERSION.
+
+use super::assert_serialized;
+use gateway_messages::UpdateError;
+
+#[test]
+fn error_enums() {
+    let response: [UpdateError; 1] = [UpdateError::InvalidPreferredSlotId];
+    let expected = vec![34];
+    assert_serialized(&expected, &response);
+}


### PR DESCRIPTION
This supports the Hubris transient boot preference feature.
When an update is attempted to the RoT alternate image and either the pending-persistent or transient boot preferences have selected that alternate image, then this error will be returned.