### PR TITLE
Add `ComponentDetails::LastPostCode`

### DIFF
--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -1344,9 +1344,31 @@ async fn run_command(
             if json {
                 return Ok(Output::Json(component_details_to_json(details)));
             }
+
+            /// Helper `struct` to pretty-print component details
+            ///
+            /// This normally delegates to `Debug`, but prints `LastPostCode` as
+            /// a hex value for convenience.
+            struct ComponentDetailPrinter(gateway_messages::ComponentDetails);
+            impl std::fmt::Display for ComponentDetailPrinter {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::fmt::Result {
+                    use gateway_messages::ComponentDetails;
+                    match &self.0 {
+                        ComponentDetails::LastPostCode(p) => {
+                            write!(f, "LastPostCode({:#x})", p.0)
+                        }
+                        d => write!(f, "{d:?}"),
+                    }
+                }
+            }
+
             let mut lines = Vec::new();
             for entry in details.entries {
-                lines.push(format!("{entry:?}"));
+                let d = ComponentDetailPrinter(entry);
+                lines.push(format!("{d}"));
             }
             Ok(Output::Lines(lines))
         }
@@ -2240,6 +2262,7 @@ fn component_details_to_json(details: SpComponentDetails) -> serde_json::Value {
     enum ComponentDetails {
         PortStatus(Result<PortStatus, PortStatusError>),
         Measurement(Measurement),
+        LastPostCode(u32),
     }
 
     #[derive(serde::Serialize)]
@@ -2262,6 +2285,9 @@ fn component_details_to_json(details: SpComponentDetails) -> serde_json::Value {
                     kind: m.kind,
                     value: m.value,
                 })
+            }
+            gateway_messages::ComponentDetails::LastPostCode(code) => {
+                ComponentDetails::LastPostCode(code.0)
             }
         })
         .collect::<Vec<_>>();

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -25,9 +25,11 @@ use serde_repr::Serialize_repr;
 pub mod ignition;
 pub mod measurement;
 pub mod monorail_port_status;
+pub mod sp5_details;
 
 pub use ignition::IgnitionState;
 pub use measurement::Measurement;
+pub use sp5_details::LastPostCode;
 
 use ignition::IgnitionError;
 use measurement::MeasurementHeader;
@@ -710,10 +712,13 @@ pub struct TlvPage {
 /// serialization traits; it only serves as an organizing collection of the
 /// possible types contained in a component details message. Each TLV-encoded
 /// struct corresponds to one of these cases.
+///
+/// As such, it is not part of the explicit message versioning scheme
 #[derive(Debug, Clone)]
 pub enum ComponentDetails {
     PortStatus(Result<PortStatus, PortStatusError>),
     Measurement(Measurement),
+    LastPostCode(LastPostCode),
 }
 
 impl ComponentDetails {
@@ -721,6 +726,7 @@ impl ComponentDetails {
         match self {
             ComponentDetails::PortStatus(_) => PortStatus::TAG,
             ComponentDetails::Measurement(_) => MeasurementHeader::TAG,
+            ComponentDetails::LastPostCode(_) => LastPostCode::TAG,
         }
     }
 
@@ -741,6 +747,9 @@ impl ComponentDetails {
                     buf[..m.name.len()].copy_from_slice(m.name.as_bytes());
                     Ok(n + m.name.len())
                 }
+            }
+            ComponentDetails::LastPostCode(code) => {
+                hubpack::serialize(buf, code)
             }
         }
     }

--- a/gateway-messages/src/sp_to_mgs/sp5_details.rs
+++ b/gateway-messages/src/sp_to_mgs/sp5_details.rs
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::tlv;
+use hubpack::SerializedSize;
+use serde::{Deserialize, Serialize};
+
+/// Most recent POST code seen by the sequencer FPGA
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, SerializedSize)]
+pub struct LastPostCode(pub u32);
+
+impl LastPostCode {
+    pub const TAG: tlv::Tag = tlv::Tag(*b"POST");
+}

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -1576,6 +1576,7 @@ impl TlvRpc for ComponentDetailsTlvRpc<'_> {
         use gateway_messages::measurement::MeasurementHeader;
         use gateway_messages::monorail_port_status::PortStatus;
         use gateway_messages::monorail_port_status::PortStatusError;
+        use gateway_messages::sp5_details::LastPostCode;
 
         match tag {
             PortStatus::TAG => {
@@ -1621,6 +1622,23 @@ impl TlvRpc for ComponentDetailsTlvRpc<'_> {
                     kind: header.kind,
                     value: header.value,
                 })))
+            }
+            LastPostCode::TAG => {
+                let (result, leftover) =
+                    gateway_messages::deserialize::<LastPostCode>(value)
+                        .map_err(|err| CommunicationError::TlvDeserialize {
+                            tag,
+                            err,
+                        })?;
+
+                if !leftover.is_empty() {
+                    info!(
+                        self.log,
+                        "ignoring unexpected data in LastPostCode TLV entry"
+                    );
+                }
+
+                Ok(Some(ComponentDetails::LastPostCode(result)))
             }
             _ => {
                 info!(


### PR DESCRIPTION
Building block for https://github.com/oxidecomputer/hubris/issues/2244

This does not require a version bump, because the TLV-encoded values are serialized as a blob and deserialized on a best-effort basis by looking at tags.