### PR TITLE
faux-mgs: de-conflict permslip --ssh-auth-sock

### DIFF
--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -575,7 +575,6 @@ enum MonorailCommand {
             long,
             alias = "online",
             conflicts_with = "list",
-            conflicts_with = "ssh_auth_sock",
             requires = "key"
         )]
         permslip: bool,


### PR DESCRIPTION
Unlocking with permslip can (and will in production) use the `SSH_AUTH_SOCK` to authenticate to the server (but not to sign the challenge response).