### PR TITLE
Update to latest hubtools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,8 +1228,8 @@ dependencies = [
 
 [[package]]
 name = "hubtools"
-version = "0.4.6"
-source = "git+https://github.com/oxidecomputer/hubtools.git?branch=main#cec2560e9a0126e9e687d51b385a57891abc87c3"
+version = "0.4.7"
+source = "git+https://github.com/oxidecomputer/hubtools.git?rev=2b1ef9b38d75563ea800baa3b17327eec17b1b7a#2b1ef9b38d75563ea800baa3b17327eec17b1b7a"
 dependencies = [
  "digest",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 
 [workspace.dependencies]
 tlvc = { git = "https://github.com/oxidecomputer/tlvc.git", branch = "main" }
-hubtools = { git = "https://github.com/oxidecomputer/hubtools.git", branch = "main"}
+hubtools = { git = "https://github.com/oxidecomputer/hubtools.git", rev = "2b1ef9b38d75563ea800baa3b17327eec17b1b7a" }
 slog-error-chain = { git = "https://github.com/oxidecomputer/slog-error-chain.git", branch = "main", features = ["derive"] }
 
 anyhow = "1.0"


### PR DESCRIPTION
Just like https://github.com/oxidecomputer/omicron/pull/9437, pin to a specific revision to avoid issues with git deps and `cargo update`.