### PR TITLE
Fix component-active-slot to not require --persist or --transient

### DIFF
--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -1492,7 +1492,12 @@ async fn run_command(
                 ]))
             }
         }
-        Command::ComponentActiveSlot { component, set, persist, .. } => {
+        Command::ComponentActiveSlot {
+            component,
+            set,
+            persist,
+            transient: _,
+        } => {
             if let Some(slot) = set {
                 sp.set_component_active_slot(component, slot, persist).await?;
                 if json {


### PR DESCRIPTION
PR #385 introduced a regression that required either --persist or --transient when setting the active slot. This broke pilot, which relies on the default behavior where no flag means transient.

Additionally, the --transient flag was incorrectly restricted to only the 'rot' component, but host-boot-flash also supports non-persistent slot changes.

Changes:
- Remove the switch_duration argument group requirement from --set
- Remove the rot-only restriction on --transient
- Add tests for argument parsing

Fixes #474