### PR TITLE
Add messages to get component persistent slot

### DIFF
--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -69,7 +69,7 @@ pub const HF_PAGE_SIZE: usize = 256;
 /// for more detail and discussion.
 pub mod version {
     pub const MIN: u32 = 2;
-    pub const CURRENT: u32 = 22;
+    pub const CURRENT: u32 = 23;
 
     /// MGS protocol version in which SP watchdog messages were added
     pub const WATCHDOG_VERSION: u32 = 12;

--- a/gateway-messages/src/mgs_to_sp.rs
+++ b/gateway-messages/src/mgs_to_sp.rs
@@ -96,7 +96,7 @@ pub enum MgsRequest {
     /// Clear any clearable state (e.g., event counters) on a component.
     ComponentClearStatus(SpComponent),
     /// For components with multiple slots (e.g., host boot flash), get the
-    /// currently-active slot.
+    /// currently-active slot. See also `ComponentGetPersistentSlot`.
     ComponentGetActiveSlot(SpComponent),
     /// For components with multiple slots (e.g., host boot flash), set the
     /// currently-active slot.
@@ -236,6 +236,11 @@ pub enum MgsRequest {
     GetHostFlashHash {
         slot: u16,
     },
+
+    /// For components with multiple slots (e.g., host boot flash), get the
+    /// current default slot as persisted in non-volatile memory. This may be
+    /// different than the current active slot (see `ComponentGetActiveSlot`).
+    ComponentGetPersistentSlot(SpComponent),
 }
 
 #[derive(

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -301,6 +301,11 @@ pub trait SpHandler {
         persist: bool,
     ) -> Result<(), SpError>;
 
+    fn component_get_persistent_slot(
+        &mut self,
+        component: SpComponent,
+    ) -> Result<u16, SpError>;
+
     fn component_action(
         &mut self,
         sender: Sender<Self::VLanId>,
@@ -906,6 +911,9 @@ fn handle_mgs_request<H: SpHandler>(
         MgsRequest::ComponentSetActiveSlot { component, slot } => handler
             .component_set_active_slot(component, slot, false)
             .map(|()| SpResponse::ComponentSetActiveSlotAck),
+        MgsRequest::ComponentGetPersistentSlot(component) => handler
+            .component_get_persistent_slot(component)
+            .map(SpResponse::ComponentPersistentSlot),
         MgsRequest::ComponentSetAndPersistActiveSlot { component, slot } => {
             handler
                 .component_set_active_slot(component, slot, true)
@@ -1330,6 +1338,13 @@ mod tests {
             _slot: u16,
             _persist: bool,
         ) -> Result<(), SpError> {
+            unimplemented!()
+        }
+
+        fn component_get_persistent_slot(
+            &mut self,
+            _component: SpComponent,
+        ) -> Result<u16, SpError> {
             unimplemented!()
         }
 

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -180,6 +180,9 @@ pub enum SpResponse {
 
     /// sha2-256 hash of a flash bank
     HostFlashHash([u8; 32]),
+
+    /// Default slot as persisted in non-volatile memory
+    ComponentPersistentSlot(u16),
 }
 
 /// Identifier for one of of an SP's KSZ8463 management-network-facing ports.

--- a/gateway-messages/tests/versioning/mod.rs
+++ b/gateway-messages/tests/versioning/mod.rs
@@ -28,6 +28,7 @@ mod v19;
 mod v20;
 mod v21;
 mod v22;
+mod v23;
 
 pub fn assert_serialized<T: Serialize + SerializedSize + std::fmt::Debug>(
     expected: &[u8],

--- a/gateway-messages/tests/versioning/v23.rs
+++ b/gateway-messages/tests/versioning/v23.rs
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! This source file is named after the protocol version being tested,
+//! e.g. v01.rs implements tests for protocol version 1.
+//! The tested protocol version is represented by "$VERSION" below.
+//!
+//! The tests in this module check that the serialized form of messages from MGS
+//! protocol version $VERSION have not changed.
+//!
+//! If a test in this module fails, _do not change the test_! This means you
+//! have changed, deleted, or reordered an existing message type or enum
+//! variant, and you should revert that change. This will remain true until we
+//! bump the `version::MIN` to a value higher than $VERSION, at which point these
+//! tests can be removed as we will stop supporting $VERSION.
+
+use super::assert_serialized;
+use gateway_messages::{MgsRequest, SpComponent, SpResponse};
+
+#[test]
+fn component_get_persistent_slot() {
+    let request =
+        MgsRequest::ComponentGetPersistentSlot(SpComponent::SP_ITSELF);
+    #[rustfmt::skip]
+    let expected = &[
+        50, // ComponentGetPersistentSlot
+        b's', b'p', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // SP_ITSELF
+    ];
+    assert_serialized(expected, &request);
+
+    let response = SpResponse::ComponentPersistentSlot(0x0102);
+    let expected = &[
+        52, // ComponentPersistentSlot
+        2, 1, // slot
+    ];
+    assert_serialized(expected, &response);
+}

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -614,6 +614,16 @@ impl SingleSp {
         })
     }
 
+    /// Get the default slot of a particular component.
+    pub async fn component_persistent_slot(
+        &self,
+        component: SpComponent,
+    ) -> Result<u16> {
+        self.rpc(MgsRequest::ComponentGetPersistentSlot(component))
+            .await
+            .and_then(expect_component_persistent_slot)
+    }
+
     /// Request that the status of a component be cleared (e.g., resetting
     /// counters).
     pub async fn component_clear_status(

--- a/gateway-sp-comms/src/sp_response_expect.rs
+++ b/gateway-sp-comms/src/sp_response_expect.rs
@@ -110,6 +110,7 @@ expect_fn!(SetStartupOptionsAck);
 expect_fn!(ComponentClearStatusAck);
 expect_fn!(ComponentActiveSlot(slot) -> u16);
 expect_fn!(ComponentSetActiveSlotAck);
+expect_fn!(ComponentPersistentSlot(slot) -> u16);
 expect_fn!(ComponentSetAndPersistActiveSlotAck);
 expect_fn!(SendHostNmiAck);
 expect_fn!(SetIpccKeyLookupValueAck);

--- a/wireshark/mgs_request.lua
+++ b/wireshark/mgs_request.lua
@@ -115,6 +115,10 @@ M.dissect_component_set_active_slot = function(buffer, pinfo, tree)
     tree:add(buffer, 'TODO: parse MgsRequest component_set_active_slot')
 end
 
+M.dissect_component_get_persistent_slot = function(buffer, pinfo, tree)
+    tree:add(buffer, 'TODO: parse MgsRequest component_get_persistent_slot')
+end
+
 M.dissect_serial_console_break = function(buffer, pinfo, tree)
     tree:add(buffer, 'TODO: parse MgsRequest serial_console_break')
 end

--- a/wireshark/protofields.lua
+++ b/wireshark/protofields.lua
@@ -94,6 +94,7 @@ M.mgs_request.names = {
     [47] = "ReadHostFlash",
     [48] = "StartHostFlashHash",
     [49] = "GetHostFlashHash",
+    [50] = "ComponentGetPersistentSlot",
 }
 M.mgs_request.handlers = {
     [0] = "dissect_discover",
@@ -146,6 +147,7 @@ M.mgs_request.handlers = {
     [47] = "dissect_read_host_flash",
     [48] = "dissect_start_host_flash_hash",
     [49] = "dissect_get_host_flash_hash",
+    [50] = "dissect_component_get_persistent_slot",
 }
 M.mgs_request.field = ProtoField.uint8(
     "mgs.mgs_request",
@@ -330,6 +332,7 @@ M.sp_response.names = {
     [49] = "ReadHostFlash",
     [50] = "StartHostFlashHashAck",
     [51] = "HostFlashHash",
+    [52] = "ComponentPersistentSlot",
 }
 M.sp_response.handlers = {
     [0] = "dissect_discover",
@@ -384,6 +387,7 @@ M.sp_response.handlers = {
     [49] = "dissect_read_host_flash",
     [50] = "dissect_start_host_flash_hash_ack",
     [51] = "dissect_host_flash_hash",
+    [52] = "dissect_component_persistent_slot",
 }
 M.sp_response.field = ProtoField.uint8(
     "mgs.sp_response",

--- a/wireshark/sp_response.lua
+++ b/wireshark/sp_response.lua
@@ -116,6 +116,10 @@ M.dissect_component_set_active_slot_ack = function(buffer, pinfo, tree)
     tree:add(buffer, 'TODO: parse SpResponse component_set_active_slot_ack')
 end
 
+M.dissect_component_persistent_slot = function(buffer, pinfo, tree)
+    tree:add(buffer, 'TODO: parse SpResponse component_persistent_slot')
+end
+
 M.dissect_serial_console_break_ack = function(buffer, pinfo, tree)
     tree:add(buffer, 'TODO: parse SpResponse serial_console_break_ack')
 end


### PR DESCRIPTION
We currently allow getting and setting the (transient) active slot. We also allow setting the active slot and persisting it but we can't read back the persisted value at a later point. We should be able to read it without changing the current (transient) active slot.