### PR TITLE
Fix SP recovery when auxflash is present

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "faux-mgs"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-sp-comms"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "backoff",

--- a/faux-mgs/Cargo.toml
+++ b/faux-mgs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faux-mgs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "MPL-2.0"
 

--- a/gateway-sp-comms/Cargo.toml
+++ b/gateway-sp-comms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway-sp-comms"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "MPL-2.0"
 

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -800,7 +800,6 @@ impl SingleSp {
                 update_id,
                 slot,
                 image,
-                None,
                 self.log(),
             )
             .await

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -800,6 +800,7 @@ impl SingleSp {
                 update_id,
                 slot,
                 image,
+                None,
                 self.log(),
             )
             .await

--- a/gateway-sp-comms/src/single_sp/update.rs
+++ b/gateway-sp-comms/src/single_sp/update.rs
@@ -815,37 +815,35 @@ async fn determine_update_resume_point_via_update_status(
     log: &Logger,
 ) -> Option<u32> {
     // We can only recover if the SP still thinks this update is in progress.
-    let progress = match super::rpc(
-        cmds_tx,
-        MgsRequest::UpdateStatus(params.component),
-        None,
-    )
-    .await
-    .result
-    .and_then(expect_update_status)
-    {
-        Ok(UpdateStatus::InProgress(progress)) => progress,
-        Ok(other_status) => {
-            error!(
-                log,
-                "invalid update chunk recovery failed: \
-                 SP update status is not in progress";
-                "status" => ?other_status,
-                "id" => %update_id,
-            );
-            return None;
-        }
-        Err(status_err) => {
-            error!(
-                log,
-                "invalid update chunk recovery failed: \
-                 could not get update status from SP";
-                &status_err,
-                "id" => %update_id,
-            );
-            return None;
-        }
-    };
+    let component = params.component;
+    let progress =
+        match super::rpc(cmds_tx, MgsRequest::UpdateStatus(component), None)
+            .await
+            .result
+            .and_then(expect_update_status)
+        {
+            Ok(UpdateStatus::InProgress(progress)) => progress,
+            Ok(other_status) => {
+                error!(
+                    log,
+                    "invalid update chunk recovery failed: \
+                     SP update status is not in progress";
+                    "status" => ?other_status,
+                    "id" => %update_id,
+                );
+                return None;
+            }
+            Err(status_err) => {
+                error!(
+                    log,
+                    "invalid update chunk recovery failed: \
+                     could not get update status from SP";
+                    &status_err,
+                    "id" => %update_id,
+                );
+                return None;
+            }
+        };
 
     let UpdateInProgressStatus { id, bytes_received, total_size } = progress;
     let id = Uuid::from(id);

--- a/gateway-sp-comms/src/single_sp/update.rs
+++ b/gateway-sp-comms/src/single_sp/update.rs
@@ -452,10 +452,8 @@ pub(super) async fn start_rot_update(
         _ => return Err(UpdateError::InvalidComponent),
     };
 
-    start_component_update(
-        cmds_tx, component, update_id, slot, rot_image, None, log,
-    )
-    .await
+    start_component_update(cmds_tx, component, update_id, slot, rot_image, log)
+        .await
 }
 
 /// Start an update to a component of the SP.
@@ -468,19 +466,10 @@ pub(super) async fn start_component_update(
     update_id: Uuid,
     slot: u16,
     image: Vec<u8>,
-    update_status_params: Option<UpdateStatusParams>,
     log: &Logger,
 ) -> Result<UpdateDriverTask, UpdateError> {
     let total_size =
         image.len().try_into().map_err(|_err| UpdateError::ImageTooLarge)?;
-
-    // Use a default set of `UpdateStatusParams` if none are provided
-    let update_status_params =
-        update_status_params.unwrap_or(UpdateStatusParams {
-            component,
-            bytes_received_offset: 0,
-            total_size_delta: 0,
-        });
 
     info!(
         log, "starting update";
@@ -507,7 +496,6 @@ pub(super) async fn start_component_update(
         component,
         update_id,
         image,
-        update_status_params,
         log.clone(),
     )))
 }
@@ -519,7 +507,6 @@ async fn drive_component_update(
     component: SpComponent,
     update_id: Uuid,
     image: Vec<u8>,
-    update_status_params: UpdateStatusParams,
     log: Logger,
 ) -> Result<(), UpdateDriverTaskError> {
     let id = update_id.into();
@@ -550,7 +537,7 @@ async fn drive_component_update(
         component,
         update_id,
         image,
-        update_status_params,
+        UpdateStatusParams::default_for(component),
         &log,
     )
     .await
@@ -790,6 +777,11 @@ pub(crate) struct UpdateStatusParams {
 }
 
 impl UpdateStatusParams {
+    /// Default parameters for a particular component
+    fn default_for(component: SpComponent) -> Self {
+        Self { component, bytes_received_offset: 0, total_size_delta: 0 }
+    }
+
     /// Parameters for sending an auxflash image before sending the SP image
     fn auxflash_before_sp(sp_image_len: usize) -> Self {
         Self {

--- a/gateway-sp-comms/src/single_sp/update.rs
+++ b/gateway-sp-comms/src/single_sp/update.rs
@@ -777,8 +777,8 @@ pub(crate) struct UpdateStatusParams {
     ///
     /// This is usually the component being updated, with one exception: if
     /// we're updating the SP's auxflash, we request the status for the
-    /// [`SP_ITSELF`] component, which returns monotonic progress for the
-    /// combined auxflash and SP update.
+    /// [`SP_ITSELF`](SpComponent::SP_ITSELF) component, which returns monotonic
+    /// progress for the combined auxflash and SP update.
     component: SpComponent,
 
     /// Value to subtract from the reported `bytes_received` value
@@ -786,7 +786,7 @@ pub(crate) struct UpdateStatusParams {
     /// This is usually 0, but if we're updating the SP image and have an
     /// auxflash image, then we must subtract the auxflash size (because the SP
     /// image is delivered after the auxflash image, and `UpdateStatus` uses a
-    /// monotonic counter from 0 to `aux_len + sp_len`.
+    /// monotonic counter from 0 to `aux_len + sp_len`).
     bytes_received_offset: usize,
 
     /// Value to subtract from the reported `total_size` value
@@ -827,6 +827,7 @@ async fn determine_update_resume_point_via_update_status(
                 "invalid update chunk recovery failed: \
                  SP update status is not in progress";
                 "status" => ?other_status,
+                "id" => %update_id,
             );
             return None;
         }
@@ -836,6 +837,7 @@ async fn determine_update_resume_point_via_update_status(
                 "invalid update chunk recovery failed: \
                  could not get update status from SP";
                 &status_err,
+                "id" => %update_id,
             );
             return None;
         }
@@ -843,34 +845,6 @@ async fn determine_update_resume_point_via_update_status(
 
     let UpdateInProgressStatus { id, bytes_received, total_size } = progress;
     let id = Uuid::from(id);
-
-    // Remap our position in the update to handle combined auxflash + SP counter
-    let Some(bytes_received) = usize::try_from(bytes_received)
-        .expect("u32 fits in usize")
-        .checked_sub(params.bytes_received_offset)
-    else {
-        error!(
-            log,
-            "invalid update chunk recovery failed: \
-             could not apply offset of {} to bytes received {}",
-            params.bytes_received_offset,
-            bytes_received
-        );
-        return None;
-    };
-    let Some(total_size) = usize::try_from(total_size)
-        .expect("u32 fits in usize")
-        .checked_sub(params.total_size_delta)
-    else {
-        error!(
-            log,
-            "invalid update chunk recovery failed: \
-             could not apply delta of {} to total size {}",
-            params.total_size_delta,
-            total_size,
-        );
-        return None;
-    };
 
     // This error check is not load-bearing; if we try to resume with our update
     // ID and some other update is in progress, the SP will reject it with a
@@ -889,6 +863,36 @@ async fn determine_update_resume_point_via_update_status(
         return None;
     }
 
+    // Remap our position in the update to handle combined auxflash + SP counter
+    let Some(bytes_received) = usize::try_from(bytes_received)
+        .expect("u32 fits in usize")
+        .checked_sub(params.bytes_received_offset)
+    else {
+        error!(
+            log,
+            "invalid update chunk recovery failed: \
+             could not apply offset to bytes received";
+            "offset" => params.bytes_received_offset,
+            "bytes_received" => bytes_received,
+            "id" => %update_id,
+        );
+        return None;
+    };
+    let Some(total_size) = usize::try_from(total_size)
+        .expect("u32 fits in usize")
+        .checked_sub(params.total_size_delta)
+    else {
+        error!(
+            log,
+            "invalid update chunk recovery failed: \
+             could not apply delta to total size";
+            "delta" => params.total_size_delta,
+            "total_size" => total_size,
+            "id" => %update_id,
+        );
+        return None;
+    };
+
     // This should never happen; if the update ID matches, we and the SP should
     // both know how long the image is.
     if total_size != image_len {
@@ -898,6 +902,7 @@ async fn determine_update_resume_point_via_update_status(
              SP expects an incorrect image length";
             "our_image_len" => image_len,
             "sp_expects_len" => total_size,
+            "id" => %update_id,
         );
         return None;
     }
@@ -912,6 +917,7 @@ async fn determine_update_resume_point_via_update_status(
              (bytes_received > total_size ?!)";
             "bytes_received" => bytes_received,
             "total_size" => total_size,
+            "id" => %update_id,
         );
         return None;
     }

--- a/gateway-sp-comms/src/single_sp/update.rs
+++ b/gateway-sp-comms/src/single_sp/update.rs
@@ -222,6 +222,7 @@ async fn drive_sp_update(
     };
 
     // Send the aux flash image, if necessary.
+    let auxflash_size = aux_image.as_ref().map(|d| d.len()).unwrap_or(0);
     if !sp_matched_chck {
         // `poll_until_update_prep_complete` can only return `Ok(false)` if we
         // told it we had an aux flash update (i.e., if `aux_image.is_some()`).
@@ -232,6 +233,11 @@ async fn drive_sp_update(
             SpComponent::SP_AUX_FLASH,
             update_id,
             data,
+            UpdateStatusParams {
+                component: SpComponent::SP_ITSELF,
+                bytes_received_offset: 0,
+                total_size_delta: sp_image.len(),
+            },
             &log,
         )
         .await
@@ -256,6 +262,11 @@ async fn drive_sp_update(
         SpComponent::SP_ITSELF,
         update_id,
         sp_image,
+        UpdateStatusParams {
+            component: SpComponent::SP_ITSELF,
+            bytes_received_offset: auxflash_size,
+            total_size_delta: auxflash_size,
+        },
         &log,
     )
     .await
@@ -449,8 +460,10 @@ pub(super) async fn start_rot_update(
         _ => return Err(UpdateError::InvalidComponent),
     };
 
-    start_component_update(cmds_tx, component, update_id, slot, rot_image, log)
-        .await
+    start_component_update(
+        cmds_tx, component, update_id, slot, rot_image, None, log,
+    )
+    .await
 }
 
 /// Start an update to a component of the SP.
@@ -463,10 +476,19 @@ pub(super) async fn start_component_update(
     update_id: Uuid,
     slot: u16,
     image: Vec<u8>,
+    update_status_params: Option<UpdateStatusParams>,
     log: &Logger,
 ) -> Result<UpdateDriverTask, UpdateError> {
     let total_size =
         image.len().try_into().map_err(|_err| UpdateError::ImageTooLarge)?;
+
+    // Use a default set of `UpdateStatusParams` if none are provided
+    let update_status_params =
+        update_status_params.unwrap_or(UpdateStatusParams {
+            component,
+            bytes_received_offset: 0,
+            total_size_delta: 0,
+        });
 
     info!(
         log, "starting update";
@@ -493,6 +515,7 @@ pub(super) async fn start_component_update(
         component,
         update_id,
         image,
+        update_status_params,
         log.clone(),
     )))
 }
@@ -504,6 +527,7 @@ async fn drive_component_update(
     component: SpComponent,
     update_id: Uuid,
     image: Vec<u8>,
+    update_status_params: UpdateStatusParams,
     log: Logger,
 ) -> Result<(), UpdateDriverTaskError> {
     let id = update_id.into();
@@ -529,8 +553,15 @@ async fn drive_component_update(
     }
 
     // Deliver the update in chunks.
-    match send_update_in_chunks(&cmds_tx, component, update_id, image, &log)
-        .await
+    match send_update_in_chunks(
+        &cmds_tx,
+        component,
+        update_id,
+        image,
+        update_status_params,
+        &log,
+    )
+    .await
     {
         Ok(()) => {
             info!(log, "update complete"; "id" => %update_id);
@@ -653,6 +684,7 @@ async fn send_update_in_chunks(
     component: SpComponent,
     update_id: Uuid,
     data: Vec<u8>,
+    update_status_params: UpdateStatusParams,
     log: &Logger,
 ) -> Result<()> {
     let mut image = Cursor::new(data);
@@ -689,9 +721,9 @@ async fn send_update_in_chunks(
                 if let Some(sp_offset) =
                     determine_update_resume_point_via_update_status(
                         cmds_tx,
-                        component,
                         update_id,
                         image.get_ref().len(),
+                        update_status_params,
                         log,
                     )
                     .await
@@ -738,6 +770,33 @@ async fn send_single_update_chunk(
     (data, result)
 }
 
+/// Parameters to be used when requesting [`UpdateStatus`]
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct UpdateStatusParams {
+    /// Component for which status should be requested
+    ///
+    /// This is usually the component being updated, with one exception: if
+    /// we're updating the SP's auxflash, we request the status for the
+    /// [`SP_ITSELF`] component, which returns monotonic progress for the
+    /// combined auxflash and SP update.
+    component: SpComponent,
+
+    /// Value to subtract from the reported `bytes_received` value
+    ///
+    /// This is usually 0, but if we're updating the SP image and have an
+    /// auxflash image, then we must subtract the auxflash size (because the SP
+    /// image is delivered after the auxflash image, and `UpdateStatus` uses a
+    /// monotonic counter from 0 to `aux_len + sp_len`.
+    bytes_received_offset: usize,
+
+    /// Value to subtract from the reported `total_size` value
+    ///
+    /// This is usually 0, but if we're updating the SP image and it has an
+    /// auxflash image then `UpdateStatus` reports a combined size and we must
+    /// subtract the _other_ component's size.
+    total_size_delta: usize,
+}
+
 /// Attempt to determine what offset the SP is expecting mid-update.
 ///
 /// We use this when receiving an `InvalidUpdateChunk` from the SP, which
@@ -746,41 +805,72 @@ async fn send_single_update_chunk(
 /// for some successful chunk that we believe we need to resend).
 async fn determine_update_resume_point_via_update_status(
     cmds_tx: &mpsc::Sender<InnerCommand>,
-    component: SpComponent,
     update_id: Uuid,
     image_len: usize,
+    params: UpdateStatusParams,
     log: &Logger,
 ) -> Option<u32> {
     // We can only recover if the SP still thinks this update is in progress.
-    let progress =
-        match super::rpc(cmds_tx, MgsRequest::UpdateStatus(component), None)
-            .await
-            .result
-            .and_then(expect_update_status)
-        {
-            Ok(UpdateStatus::InProgress(progress)) => progress,
-            Ok(other_status) => {
-                error!(
-                    log,
-                    "invalid update chunk recovery failed: \
-                     SP update status is not in progress";
-                    "status" => ?other_status,
-                );
-                return None;
-            }
-            Err(status_err) => {
-                error!(
-                    log,
-                    "invalid update chunk recovery failed: \
-                     could not get update status from SP";
-                    &status_err,
-                );
-                return None;
-            }
-        };
+    let progress = match super::rpc(
+        cmds_tx,
+        MgsRequest::UpdateStatus(params.component),
+        None,
+    )
+    .await
+    .result
+    .and_then(expect_update_status)
+    {
+        Ok(UpdateStatus::InProgress(progress)) => progress,
+        Ok(other_status) => {
+            error!(
+                log,
+                "invalid update chunk recovery failed: \
+                 SP update status is not in progress";
+                "status" => ?other_status,
+            );
+            return None;
+        }
+        Err(status_err) => {
+            error!(
+                log,
+                "invalid update chunk recovery failed: \
+                 could not get update status from SP";
+                &status_err,
+            );
+            return None;
+        }
+    };
 
     let UpdateInProgressStatus { id, bytes_received, total_size } = progress;
     let id = Uuid::from(id);
+
+    // Remap our position in the update to handle combined auxflash + SP counter
+    let Some(bytes_received) = usize::try_from(bytes_received)
+        .expect("u32 fits in usize")
+        .checked_sub(params.bytes_received_offset)
+    else {
+        error!(
+            log,
+            "invalid update chunk recovery failed: \
+             could not apply offset of {} to bytes received {}",
+            params.bytes_received_offset,
+            bytes_received
+        );
+        return None;
+    };
+    let Some(total_size) = usize::try_from(total_size)
+        .expect("u32 fits in usize")
+        .checked_sub(params.total_size_delta)
+    else {
+        error!(
+            log,
+            "invalid update chunk recovery failed: \
+             could not apply delta of {} to total size {}",
+            params.total_size_delta,
+            total_size,
+        );
+        return None;
+    };
 
     // This error check is not load-bearing; if we try to resume with our update
     // ID and some other update is in progress, the SP will reject it with a
@@ -801,7 +891,7 @@ async fn determine_update_resume_point_via_update_status(
 
     // This should never happen; if the update ID matches, we and the SP should
     // both know how long the image is.
-    if usize::try_from(total_size).expect("u32 fits in usize") != image_len {
+    if total_size != image_len {
         error!(
             log,
             "invalid update chunk recovery failed: \
@@ -831,5 +921,5 @@ async fn determine_update_resume_point_via_update_status(
         "invalid update chunk recovery: attempting to resume \
          from offset {bytes_received}"
     );
-    Some(bytes_received)
+    Some(u32::try_from(bytes_received).expect("round-trip conversion"))
 }

--- a/gateway-sp-comms/src/single_sp/update.rs
+++ b/gateway-sp-comms/src/single_sp/update.rs
@@ -233,11 +233,7 @@ async fn drive_sp_update(
             SpComponent::SP_AUX_FLASH,
             update_id,
             data,
-            UpdateStatusParams {
-                component: SpComponent::SP_ITSELF,
-                bytes_received_offset: 0,
-                total_size_delta: sp_image.len(),
-            },
+            UpdateStatusParams::auxflash_before_sp(sp_image.len()),
             &log,
         )
         .await
@@ -262,11 +258,7 @@ async fn drive_sp_update(
         SpComponent::SP_ITSELF,
         update_id,
         sp_image,
-        UpdateStatusParams {
-            component: SpComponent::SP_ITSELF,
-            bytes_received_offset: auxflash_size,
-            total_size_delta: auxflash_size,
-        },
+        UpdateStatusParams::sp_after_auxflash(auxflash_size),
         &log,
     )
     .await
@@ -795,6 +787,26 @@ pub(crate) struct UpdateStatusParams {
     /// auxflash image then `UpdateStatus` reports a combined size and we must
     /// subtract the _other_ component's size.
     total_size_delta: usize,
+}
+
+impl UpdateStatusParams {
+    /// Parameters for sending an auxflash image before sending the SP image
+    fn auxflash_before_sp(sp_image_len: usize) -> Self {
+        Self {
+            component: SpComponent::SP_ITSELF,
+            bytes_received_offset: 0,
+            total_size_delta: sp_image_len,
+        }
+    }
+
+    /// Parameters for sending an SP image after sending the auxflash image
+    fn sp_after_auxflash(auxflash_len: usize) -> Self {
+        Self {
+            component: SpComponent::SP_ITSELF,
+            bytes_received_offset: auxflash_len,
+            total_size_delta: auxflash_len,
+        }
+    }
 }
 
 /// Attempt to determine what offset the SP is expecting mid-update.


### PR DESCRIPTION
Fixes #486 (see that issue's excellent writeup for additional context)

This PR allows component updates to fine-tune how they handle `UpdateStatus` during recovery.

Specifically, they can override the component for which they request update status, then apply offsets to both the byte position and the total image size.  For most components, this isn't necessary, but it's critical for the combined SP + auxflash image: we must request `SP_ITSELF` as the `UpdateStatus` target component (even when updating the auxflash), and compensate for the other image size when interpreting the results.

I tested this by adding fault injection to the SP firmware, causing it to drop 5% of packets:
```diff
diff --git a/task/control-plane-agent/src/main.rs b/task/control-plane-agent/src/main.rs
index bfb414e2b3..16ba76a6e2 100644
--- a/task/control-plane-agent/src/main.rs
+++ b/task/control-plane-agent/src/main.rs
@@ -607,8 +607,11 @@
             mgs_handler,
             self.tx_buf,
         ) {
-            meta.size = n as u32;
-            self.packet_to_send = Some(meta);
+            // XXX drop 5% of outgoing packets
+            if userlib::sys_get_timer().now % 20 != 0 {
+                meta.size = n as u32;
+                self.packet_to_send = Some(meta);
+            }
         }
     }
 }
```

Doing a `faux-mgs` update without this patch, I reproduce the behavior in #486.

With this patch in place, I see that recovery is happening.  Here's a console log when updating both the auxflash and SP image (adding a small random blob to auxflash to force an update):
```console
$ cargo run -pfaux-mgs -- --interface=en9 update sp 0 $HUMILITY_ARCHIVE
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/faux-mgs --interface=en9 update sp 0 /Users/mjk/oxide/hubris/target/grapefruit-a/dist/default/build-grapefruit-a-image-default.zip`
Apr 21 10:29:14.593 INFO creating SP handle on interface en9, component: faux-mgs
Apr 21 10:29:14.595 INFO generated update ID, id: 43775c4e-0743-4811-8a8e-b34f5c4ac298, component: faux-mgs
Apr 21 10:29:14.596 INFO initial discovery complete, addr: [fe80::c1d:8cff:fec0:e207%28]:11111, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:29:14.643 INFO starting SP update, sp_image_size: 557312, aux_flash_size: 354532, aux_flash_chck: [7, 36, 42, 96, 148, 52, 210, 110, 42, 228, 24, 187, 16, 15, 192, 239, 201, 150, 9, 172, 106, 148, 70, 202, 145, 182, 219, 146, 109, 191, 9, 20], id: 43775c4e-0743-4811-8a8e-b34f5c4ac298, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:29:19.422 WARN ignoring unexpected RPC response, message: Message { header: Header { version: 25, message_id: 3 }, kind: SpResponse(Error(UpdateInProgress(Preparing(UpdatePreparationStatus { id: UpdateId([67, 119, 92, 78, 7, 67, 72, 17, 138, 142, 179, 79, 92, 74, 194, 152]), progress: Some(UpdatePreparationProgress { current: 0, total: 48 }) })))) }, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:29:19.423 WARN ignoring unexpected RPC response, message: Message { header: Header { version: 25, message_id: 3 }, kind: SpResponse(Error(UpdateInProgress(Preparing(UpdatePreparationStatus { id: UpdateId([67, 119, 92, 78, 7, 67, 72, 17, 138, 142, 179, 79, 92, 74, 194, 152]), progress: Some(UpdatePreparationProgress { current: 0, total: 48 }) })))) }, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:29:21.607 INFO update preparing: 22/48, component: faux-mgs
Apr 21 10:29:22.638 INFO update preparing: 29/48, component: faux-mgs
Apr 21 10:29:23.671 INFO update preparing: 36/48, component: faux-mgs
Apr 21 10:29:24.714 INFO update preparing: 43/48, component: faux-mgs
Apr 21 10:29:25.717 INFO aux flash scan complete, total_size: 911844, found_match: false, component: faux-mgs
Apr 21 10:29:25.821 INFO update preparation complete, update_id: 43775c4e-0743-4811-8a8e-b34f5c4ac298, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:29:29.870 WARN received invalid update chunk from SP; attempting recovery, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:29:29.871 INFO update in progress, total_size: 911844, bytes_received: 18582, component: faux-mgs
Apr 21 10:29:29.872 WARN invalid update chunk recovery: attempting to resume from offset 18582, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:29:31.929 WARN received invalid update chunk from SP; attempting recovery, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:29:31.930 INFO update in progress, total_size: 911844, bytes_received: 41076, component: faux-mgs
Apr 21 10:29:31.930 WARN invalid update chunk recovery: attempting to resume from offset 41076, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:29:33.950 WARN received invalid update chunk from SP; attempting recovery, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:29:33.950 INFO update in progress, total_size: 911844, bytes_received: 47922, component: faux-mgs
Apr 21 10:29:33.951 WARN invalid update chunk recovery: attempting to resume from offset 47922, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:29:35.969 WARN received invalid update chunk from SP; attempting recovery, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:29:35.970 INFO update in progress, total_size: 911844, bytes_received: 54768, component: faux-mgs
Apr 21 10:29:35.970 WARN invalid update chunk recovery: attempting to resume from offset 54768, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:29:38.029 WARN received invalid update chunk from SP; attempting recovery, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:29:38.030 INFO update in progress, total_size: 911844, bytes_received: 76284, component: faux-mgs
Apr 21 10:29:38.031 WARN invalid update chunk recovery: attempting to resume from offset 76284, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:29:40.109 WARN received invalid update chunk from SP; attempting recovery, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:29:40.110 INFO update in progress, total_size: 911844, bytes_received: 105624, component: faux-mgs
[...etc...]
Apr 21 10:31:56.687 WARN received invalid update chunk from SP; attempting recovery, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:31:56.688 INFO update in progress, total_size: 911844, bytes_received: 878740, component: faux-mgs
Apr 21 10:31:56.689 WARN invalid update chunk recovery: attempting to resume from offset 524208, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:31:58.744 WARN received invalid update chunk from SP; attempting recovery, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:32:00.748 INFO update in progress, total_size: 911844, bytes_received: 894388, component: faux-mgs
Apr 21 10:32:00.749 WARN invalid update chunk recovery: attempting to resume from offset 539856, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:32:02.767 WARN received invalid update chunk from SP; attempting recovery, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:32:02.768 INFO update in progress, total_size: 911844, bytes_received: 899278, component: faux-mgs
Apr 21 10:32:02.769 WARN invalid update chunk recovery: attempting to resume from offset 544746, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:32:03.114 INFO update complete, id: 43775c4e-0743-4811-8a8e-b34f5c4ac298, interface: en9, socket: control-plane-agent, component: faux-mgs
update complete
```

Re-running the same update, we see that we skip the auxflash update (`found_match: true` and `bytes_received` starts above `aux_flash_size: 354532`), and recovery still works:
```console
$ cargo run -pfaux-mgs -- --interface=en9 update sp 0 $HUMILITY_ARCHIVE
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/faux-mgs --interface=en9 update sp 0 /Users/mjk/oxide/hubris/target/grapefruit-a/dist/default/build-grapefruit-a-image-default.zip`
Apr 21 10:32:59.652 INFO creating SP handle on interface en9, component: faux-mgs
Apr 21 10:32:59.654 INFO generated update ID, id: 9421eed2-19bd-4bb0-8b9c-923a54e80738, component: faux-mgs
Apr 21 10:32:59.655 INFO initial discovery complete, addr: [fe80::c1d:8cff:fec0:e207%28]:11111, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:32:59.702 INFO starting SP update, sp_image_size: 557312, aux_flash_size: 354532, aux_flash_chck: [7, 36, 42, 96, 148, 52, 210, 110, 42, 228, 24, 187, 16, 15, 192, 239, 201, 150, 9, 172, 106, 148, 70, 202, 145, 182, 219, 146, 109, 191, 9, 20], id: 9421eed2-19bd-4bb0-8b9c-923a54e80738, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:33:04.350 INFO update preparing: 0/48, component: faux-mgs
Apr 21 10:33:04.350 WARN ignoring unexpected RPC response, message: Message { header: Header { version: 25, message_id: 5 }, kind: SpResponse(UpdateStatus(Preparing(UpdatePreparationStatus { id: UpdateId([148, 33, 238, 210, 25, 189, 75, 176, 139, 156, 146, 58, 84, 232, 7, 56]), progress: Some(UpdatePreparationProgress { current: 0, total: 48 }) }))) }, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:33:04.350 WARN ignoring unexpected RPC response, message: Message { header: Header { version: 25, message_id: 5 }, kind: SpResponse(UpdateStatus(Preparing(UpdatePreparationStatus { id: UpdateId([148, 33, 238, 210, 25, 189, 75, 176, 139, 156, 146, 58, 84, 232, 7, 56]), progress: Some(UpdatePreparationProgress { current: 0, total: 48 }) }))) }, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:33:05.353 INFO aux flash scan complete, total_size: 911844, found_match: true, component: faux-mgs
Apr 21 10:33:06.351 INFO update preparation complete, update_id: 9421eed2-19bd-4bb0-8b9c-923a54e80738, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:33:06.356 INFO update in progress, total_size: 911844, bytes_received: 356488, component: faux-mgs
Apr 21 10:33:10.369 WARN received invalid update chunk from SP; attempting recovery, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:33:10.370 INFO update in progress, total_size: 911844, bytes_received: 359422, component: faux-mgs
Apr 21 10:33:10.370 WARN invalid update chunk recovery: attempting to resume from offset 4890, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:33:14.429 WARN received invalid update chunk from SP; attempting recovery, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:33:14.430 INFO update in progress, total_size: 911844, bytes_received: 375070, component: faux-mgs
Apr 21 10:33:14.430 WARN invalid update chunk recovery: attempting to resume from offset 20538, interface: en9, socket: control-plane-agent, component: faux-mgs
[...snip...]
Apr 21 10:35:04.286 INFO update in progress, total_size: 911844, bytes_received: 908080, component: faux-mgs
Apr 21 10:35:04.286 WARN invalid update chunk recovery: attempting to resume from offset 553548, interface: en9, socket: control-plane-agent, component: faux-mgs
Apr 21 10:35:04.596 INFO update complete, id: 9421eed2-19bd-4bb0-8b9c-923a54e80738, interface: en9, socket: control-plane-agent, component: faux-mgs
update complete
```

Running `humility flash --check` confirms that the image is correct:
```console
$ humility flash --check
humility: attached to archive
humility: attaching with chip set to "STM32H753ZITx"
humility: attached via ST-Link V3
humility: verified 544.25KB in 23 seconds
humility: verified auxflash in slot 2
```