### PR TITLE
gateway-messages: add `HAS_VPD` and `IS_PMBUS` capabilities

### DIFF
--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -906,6 +906,15 @@ bitflags! {
         const HAS_MEASUREMENT_CHANNELS = 1 << 1;
         const HAS_SERIAL_CONSOLE = 1 << 2;
         const IS_LED = 1 << 3;
+        /// The device has vital product data, such as a part numbe and serial
+        /// number
+        const HAS_VPD = 1 << 4;
+        /// This is a PMBus device.
+        ///
+        /// This implies that the device `HAS_MEASUREMENT_CHANNELS` and
+        /// `HAS_VPD`, but also indicates that the device has PMBus status
+        /// registers.
+        const IS_PMBUS = 1 << 5;
         // MGS has a placeholder API for powering off an individual component;
         // do we want to keep that? If so, add a bit for "can be powered on and
         // off".

--- a/gateway-messages/src/sp_to_mgs.rs
+++ b/gateway-messages/src/sp_to_mgs.rs
@@ -906,7 +906,7 @@ bitflags! {
         const HAS_MEASUREMENT_CHANNELS = 1 << 1;
         const HAS_SERIAL_CONSOLE = 1 << 2;
         const IS_LED = 1 << 3;
-        /// The device has vital product data, such as a part numbe and serial
+        /// The device has vital product data, such as a part number and serial
         /// number
         const HAS_VPD = 1 << 4;
         /// This is a PMBus device.


### PR DESCRIPTION
This commit adds new `HAS_VPD` and `IS_PMBUS` bits to the `DeviceCapabilities` bitfield, which will indicate when a device has vital product data, and when a device is a PMBus device, respectively. This is being added separately from actually implementing any of these capabilities mostly in order to avoid future merge conflicts here.