### PR TITLE
gateway-sp-comms: remove null bytes from CBOR strings

### DIFF
--- a/gateway-sp-comms/src/ereport.rs
+++ b/gateway-sp-comms/src/ereport.rs
@@ -575,7 +575,18 @@ fn convert_cbor_value(value: CborValue) -> Result<JsonValue, CborToJsonError> {
             convert_cbor_object_into(cbor, &mut json)?;
             JsonValue::Object(json)
         }
-        CborValue::Text(s) => JsonValue::String(s),
+        CborValue::Text(s) => {
+            // Strip null bytes from the start and end of the string, in case it
+            // came from a null-padded byte array in Hubris. We do this
+            // conditionally on the presence of such bytes, because it should be
+            // unnecessary to reallocate if we aren't stripping nulls.
+            let s = if s.starts_with('\0') || s.ends_with('\0') {
+                s.trim_matches('\0').to_string()
+            } else {
+                s
+            };
+            JsonValue::String(s)
+        }
 
         // Per RFC 8949 section 6.1:
         //


### PR DESCRIPTION
This will remove any pesky trailing NULLs in OXV2 serial numbers, and also in ANY OTHER STRING because there is NO UNIVERSE IN WHICH WE ACTUALLY WANT SEVERAL BYTES OF `\0` APPENDED TO ANY STRING EVER.

This is part of the fix for oxidecomputer/omicron#10437. In parallel, I'm gonna go write a database migration to clean up any already nully serial numbers in the control plane's database. 