### PR TITLE
faux-mgs: less eye-bleedy ereport pretty-printer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
  "terminal_size",
 ]
 
@@ -399,7 +399,7 @@ dependencies = [
  "camino",
  "camino-tempfile",
  "clap",
- "convert_case",
+ "convert_case 0.8.0",
  "expectorate",
  "gateway-messages",
  "strum",
@@ -442,6 +442,12 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"
@@ -583,6 +589,41 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -746,8 +787,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "erebor"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/erebor?rev=400a0faa1adaef7bc29d9ec39d724b27a9efb3df#400a0faa1adaef7bc29d9ec39d724b27a9efb3df"
+source = "git+https://github.com/oxidecomputer/erebor?rev=eff27fb3a652e993a62c8babe327108538fcde53#eff27fb3a652e993a62c8babe327108538fcde53"
 dependencies = [
+ "pmbus",
  "serde_json",
 ]
 
@@ -1444,6 +1486,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,6 +1862,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2115,6 +2174,21 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "pmbus"
+version = "0.1.7"
+source = "git+https://github.com/oxidecomputer/pmbus?rev=3e681b17aafce32e80e06aff2dd841c9153cf069#3e681b17aafce32e80e06aff2dd841c9153cf069"
+dependencies = [
+ "anyhow",
+ "convert_case 0.4.0",
+ "libm",
+ "num-derive",
+ "num-traits",
+ "ron",
+ "serde",
+ "serde_with",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2690,6 +2764,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2941,6 +3037,12 @@ dependencies = [
  "precomputed-hash",
  "serde",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "erebor"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/erebor?rev=eff27fb3a652e993a62c8babe327108538fcde53#eff27fb3a652e993a62c8babe327108538fcde53"
+source = "git+https://github.com/oxidecomputer/erebor?rev=d41644dc6ec8396415712a2863edbee73d6e7ab9#d41644dc6ec8396415712a2863edbee73d6e7ab9"
 dependencies = [
  "pmbus",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,6 +744,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erebor"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/erebor?rev=400a0faa1adaef7bc29d9ec39d724b27a9efb3df#400a0faa1adaef7bc29d9ec39d724b27a9efb3df"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +787,7 @@ dependencies = [
  "camino",
  "clap",
  "colored",
+ "erebor",
  "futures",
  "gateway-messages",
  "gateway-sp-comms",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "erebor"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/erebor?rev=d41644dc6ec8396415712a2863edbee73d6e7ab9#d41644dc6ec8396415712a2863edbee73d6e7ab9"
+source = "git+https://github.com/oxidecomputer/erebor?rev=48512bf970474ff0fd0868c833fd504c8d169064#48512bf970474ff0fd0868c833fd504c8d169064"
 dependencies = [
  "pmbus",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ camino-tempfile = "1.4.1"
 clap = { version = "4.5", features = ["derive", "env"] }
 colored = "3"
 convert_case = "0.8"
-erebor = { git = "https://github.com/oxidecomputer/erebor", rev = "d41644dc6ec8396415712a2863edbee73d6e7ab9" }
+erebor = { git = "https://github.com/oxidecomputer/erebor", rev = "48512bf970474ff0fd0868c833fd504c8d169064" }
 expectorate = "=1.1.0" # 1.2 requires rust 1.75; bump eventually
 futures = "0.3.31"
 fxhash = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ camino-tempfile = "1.4.1"
 clap = { version = "4.5", features = ["derive", "env"] }
 colored = "3"
 convert_case = "0.8"
+erebor = { git = "https://github.com/oxidecomputer/erebor", rev = "400a0faa1adaef7bc29d9ec39d724b27a9efb3df"}
 expectorate = "=1.1.0" # 1.2 requires rust 1.75; bump eventually
 futures = "0.3.31"
 fxhash = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ camino-tempfile = "1.4.1"
 clap = { version = "4.5", features = ["derive", "env"] }
 colored = "3"
 convert_case = "0.8"
-erebor = { git = "https://github.com/oxidecomputer/erebor", rev = "eff27fb3a652e993a62c8babe327108538fcde53"}
+erebor = { git = "https://github.com/oxidecomputer/erebor", rev = "eff27fb3a652e993a62c8babe327108538fcde53" }
 expectorate = "=1.1.0" # 1.2 requires rust 1.75; bump eventually
 futures = "0.3.31"
 fxhash = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ camino-tempfile = "1.4.1"
 clap = { version = "4.5", features = ["derive", "env"] }
 colored = "3"
 convert_case = "0.8"
-erebor = { git = "https://github.com/oxidecomputer/erebor", rev = "eff27fb3a652e993a62c8babe327108538fcde53" }
+erebor = { git = "https://github.com/oxidecomputer/erebor", rev = "d41644dc6ec8396415712a2863edbee73d6e7ab9" }
 expectorate = "=1.1.0" # 1.2 requires rust 1.75; bump eventually
 futures = "0.3.31"
 fxhash = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ camino-tempfile = "1.4.1"
 clap = { version = "4.5", features = ["derive", "env"] }
 colored = "3"
 convert_case = "0.8"
-erebor = { git = "https://github.com/oxidecomputer/erebor", rev = "400a0faa1adaef7bc29d9ec39d724b27a9efb3df"}
+erebor = { git = "https://github.com/oxidecomputer/erebor", rev = "eff27fb3a652e993a62c8babe327108538fcde53"}
 expectorate = "=1.1.0" # 1.2 requires rust 1.75; bump eventually
 futures = "0.3.31"
 fxhash = "0.2.1"

--- a/faux-mgs/Cargo.toml
+++ b/faux-mgs/Cargo.toml
@@ -10,6 +10,7 @@ async-trait.workspace = true
 camino.workspace = true
 clap.workspace = true
 colored.workspace = true
+erebor.workspace = true
 futures.workspace = true
 glob.workspace = true
 hex.workspace = true

--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -2398,7 +2398,8 @@ async fn run_command(
                     ereport.ena.into_u64(),
                 ));
                 lines.push(String::new());
-                let pretty = erebor::Displayer::new(&ereport.data).to_string();
+                let data = serde_json::Value::Object(ereport.data);
+                let pretty = erebor::Displayer::new(&data).to_string();
                 lines.push(pretty);
             }
 

--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -2332,8 +2332,6 @@ async fn run_command(
             restart_id: req_restart_id,
             limit,
         } => {
-            use std::fmt::Write;
-
             anyhow::ensure!(
                 committed_ena <= Some(start_ena),
                 "`--committed-ena` argument must be less than or equal to \
@@ -2379,115 +2377,6 @@ async fn run_command(
                 "TIME", "CLASS", "ENA"
             );
 
-            enum Name<'a> {
-                Key(&'a str),
-                ArrayIndex(&'a Name<'a>, usize),
-            }
-
-            impl std::fmt::Display for Name<'_> {
-                fn fmt(
-                    &self,
-                    f: &mut std::fmt::Formatter<'_>,
-                ) -> std::fmt::Result {
-                    match self {
-                        Name::Key(key) => write!(f, "{key}"),
-                        Name::ArrayIndex(key, index) => {
-                            write!(f, "{key}[{index}]")
-                        }
-                    }
-                }
-            }
-
-            fn prettyprint_json(
-                buf: &mut String,
-                indent: usize,
-                name: Name<'_>,
-                value: &serde_json::Value,
-            ) {
-                match value {
-                    serde_json::Value::Object(obj) => {
-                        buf.push_str("(object)\n");
-                        prettyprint_json_obj(buf, indent + 4, obj);
-                        if !obj.is_empty() {
-                            writeln!(buf, "{:>indent$}(end {name})", "")
-                                .expect(
-                                    "writing to a string should always work",
-                                );
-                        }
-                    }
-                    serde_json::Value::Array(arr) => {
-                        writeln!(buf, "(array of {} elements)", arr.len())
-                            .expect("writing to a string should always work");
-                        if !arr.is_empty() {
-                            for (idx, value) in arr.iter().enumerate() {
-                                let indent = indent + 4;
-                                write!(buf, "{:>indent$}", "").expect(
-                                    "writing to a string should always work",
-                                );
-                                prettyprint_json(
-                                    buf,
-                                    indent,
-                                    Name::ArrayIndex(&name, idx),
-                                    value,
-                                );
-                                buf.push('\n');
-                            }
-                            writeln!(buf, "{:>indent$}(end {name})", "")
-                                .expect(
-                                    "writing to a string should always work",
-                                );
-                        }
-                    }
-                    serde_json::Value::String(s) => {
-                        if !s.contains('\n') {
-                            buf.push_str(s);
-                        } else {
-                            let indent = indent + 4;
-                            let mut lines = s.lines();
-                            if let Some(line) = lines.next() {
-                                writeln!(buf, "\n{:>indent$}{line}", "").expect(
-                                    "writing to a string should always work",
-                                );
-                                for line in lines {
-                                    writeln!(buf, "{:>indent$}{line}", "").expect(
-                                        "writing to a string should always work",
-                                    );
-                                }
-                            }
-                        }
-                    }
-                    serde_json::Value::Number(n) => {
-                        buf.push_str(&n.to_string());
-                    }
-                    serde_json::Value::Bool(b) => {
-                        buf.push_str(if *b { "true" } else { "false" });
-                    }
-                    serde_json::Value::Null => {
-                        buf.push_str(NULL);
-                    }
-                }
-            }
-
-            fn prettyprint_json_obj(
-                buf: &mut String,
-                indent: usize,
-                obj: &serde_json::Map<String, serde_json::Value>,
-            ) {
-                for (key, value) in obj {
-                    let key = if key == "k" {
-                        "class"
-                    } else if key == "v" {
-                        "version"
-                    } else {
-                        key.as_ref()
-                    };
-                    write!(buf, "{:>indent$}{key} = ", "")
-                        .expect("writing to a string works okay");
-                    prettyprint_json(buf, indent, Name::Key(key), value);
-                    buf.push('\n');
-                }
-            }
-
             for ereport in ereports {
                 lines.push(header.clone());
                 let uptime: &dyn std::fmt::Display =
@@ -2509,9 +2398,8 @@ async fn run_command(
                     ereport.ena.into_u64(),
                 ));
                 lines.push(String::new());
-                let mut buf = String::new();
-                prettyprint_json_obj(&mut buf, 0, &ereport.data);
-                lines.push(buf);
+                let pretty = erebor::Displayer::new(&ereport.data).to_string();
+                lines.push(pretty);
             }
 
             Ok(Output::Lines(lines))

--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -2332,6 +2332,8 @@ async fn run_command(
             restart_id: req_restart_id,
             limit,
         } => {
+            use std::fmt::Write;
+
             anyhow::ensure!(
                 committed_ena <= Some(start_ena),
                 "`--committed-ena` argument must be less than or equal to \
@@ -2377,20 +2379,63 @@ async fn run_command(
                 "TIME", "CLASS", "ENA"
             );
 
-            use std::fmt::Write;
+            enum Name<'a> {
+                Key(&'a str),
+                ArrayIndex(&'a Name<'a>, usize),
+            }
+
+            impl std::fmt::Display for Name<'_> {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::fmt::Result {
+                    match self {
+                        Name::Key(key) => write!(f, "{key}"),
+                        Name::ArrayIndex(key, index) => {
+                            write!(f, "{key}[{index}]")
+                        }
+                    }
+                }
+            }
+
             fn prettyprint_json(
                 buf: &mut String,
                 indent: usize,
+                name: Name<'_>,
                 value: &serde_json::Value,
             ) {
                 match value {
                     serde_json::Value::Object(obj) => {
-                        prettyprint_json_obj(buf, indent + 2, obj);
+                        buf.push_str("(object)\n");
+                        prettyprint_json_obj(buf, indent + 4, obj);
+                        if !obj.is_empty() {
+                            writeln!(buf, "{:>indent$}(end {name})", "")
+                                .expect(
+                                    "writing to a string should always work",
+                                );
+                        }
                     }
                     serde_json::Value::Array(arr) => {
-                        for value in arr {
-                            prettyprint_json(buf, indent + 2, value);
-                            buf.push('\n');
+                        writeln!(buf, "(array of {} elements)", arr.len())
+                            .expect("writing to a string should always work");
+                        if !arr.is_empty() {
+                            for (idx, value) in arr.iter().enumerate() {
+                                let indent = indent + 4;
+                                write!(buf, "{:>indent$}", "").expect(
+                                    "writing to a string should always work",
+                                );
+                                prettyprint_json(
+                                    buf,
+                                    indent,
+                                    Name::ArrayIndex(&name, idx),
+                                    value,
+                                );
+                                buf.push('\n');
+                            }
+                            writeln!(buf, "{:>indent$}(end {name})", "")
+                                .expect(
+                                    "writing to a string should always work",
+                                );
                         }
                     }
                     serde_json::Value::String(s) => {
@@ -2413,24 +2458,21 @@ async fn run_command(
                 indent: usize,
                 obj: &serde_json::Map<String, serde_json::Value>,
             ) {
-                if obj.is_empty() {
+                for (key, value) in obj {
+                    let key = if key == "k" {
+                        "class"
+                    } else if key == "v" {
+                        "version"
+                    } else {
+                        key.as_ref()
+                    };
+                    write!(buf, "{:>indent$}{key} = ", "")
+                        .expect("writing to a string works okay");
+                    prettyprint_json(buf, indent, Name::Key(key), value);
                     buf.push('\n');
-                } else {
-                    for (key, value) in obj {
-                        let key = if key == "k" {
-                            "class"
-                        } else if key == "v" {
-                            "version"
-                        } else {
-                            key.as_ref()
-                        };
-                        write!(buf, "{:>indent$}{key} = ", "")
-                            .expect("writing to a string works okay");
-                        prettyprint_json(buf, indent, value);
-                        buf.push('\n');
-                    }
                 }
             }
+
             for ereport in ereports {
                 lines.push(header.clone());
                 let uptime: &dyn std::fmt::Display =

--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -2366,12 +2366,95 @@ async fn run_command(
             lines.push(String::new());
             lines.push("ereports:".to_string());
 
+            const WRONG_TYPE: &str = "<wrong type>";
+            const NULL: &str = "<null>";
+            const MAX_UPTIME_DIGITS: usize = 12;
+            const MAX_ENA_DIGITS: usize = 18;
+            const MAX_CLASS: usize =
+                79 - MAX_UPTIME_DIGITS - MAX_ENA_DIGITS - 4;
+            let header = format!(
+                "{:<MAX_UPTIME_DIGITS$} {:<MAX_CLASS$} {:<MAX_ENA_DIGITS$}",
+                "TIME", "CLASS", "ENA"
+            );
+
+            use std::fmt::Write;
+            fn prettyprint_json(
+                buf: &mut String,
+                indent: usize,
+                value: &serde_json::Value,
+            ) {
+                match value {
+                    serde_json::Value::Object(obj) => {
+                        prettyprint_json_obj(buf, indent + 2, obj);
+                    }
+                    serde_json::Value::Array(arr) => {
+                        for value in arr {
+                            prettyprint_json(buf, indent + 2, value);
+                            buf.push('\n');
+                        }
+                    }
+                    serde_json::Value::String(s) => {
+                        buf.push_str(s);
+                    }
+                    serde_json::Value::Number(n) => {
+                        buf.push_str(&n.to_string());
+                    }
+                    serde_json::Value::Bool(b) => {
+                        buf.push_str(if *b { "true" } else { "false" });
+                    }
+                    serde_json::Value::Null => {
+                        buf.push_str(NULL);
+                    }
+                }
+            }
+
+            fn prettyprint_json_obj(
+                buf: &mut String,
+                indent: usize,
+                obj: &serde_json::Map<String, serde_json::Value>,
+            ) {
+                if obj.is_empty() {
+                    buf.push('\n');
+                } else {
+                    for (key, value) in obj {
+                        let key = if key == "k" {
+                            "class"
+                        } else if key == "v" {
+                            "version"
+                        } else {
+                            key.as_ref()
+                        };
+                        write!(buf, "{:>indent$}{key} = ", "")
+                            .expect("writing to a string works okay");
+                        prettyprint_json(buf, indent, value);
+                        buf.push('\n');
+                    }
+                }
+            }
             for ereport in ereports {
+                lines.push(header.clone());
+                let uptime: &dyn std::fmt::Display =
+                    match ereport.data.get("hubris_uptime_ms") {
+                        Some(serde_json::Value::Number(n)) => {
+                            &n.as_u64().unwrap_or(u64::MAX)
+                        }
+                        Some(_) => &WRONG_TYPE,
+                        None => &NULL,
+                    };
+                let class = match ereport.data.get("k") {
+                    Some(serde_json::Value::String(c)) => c.as_str(),
+                    Some(_) => WRONG_TYPE,
+                    None => NULL,
+                };
                 lines.push(format!(
-                    "{:#x}: {:#?}\n",
+                    "{uptime:<MAX_UPTIME_DIGITS$} {class:<MAX_CLASS$} \
+                     {:<#0MAX_ENA_DIGITS$x}",
                     ereport.ena.into_u64(),
-                    ereport.data
                 ));
+                lines.push(String::new());
+                let mut buf = String::new();
+                prettyprint_json_obj(&mut buf, 0, &ereport.data);
+                lines.push(buf);
             }
 
             Ok(Output::Lines(lines))

--- a/faux-mgs/src/main.rs
+++ b/faux-mgs/src/main.rs
@@ -2439,7 +2439,22 @@ async fn run_command(
                         }
                     }
                     serde_json::Value::String(s) => {
-                        buf.push_str(s);
+                        if !s.contains('\n') {
+                            buf.push_str(s);
+                        } else {
+                            let indent = indent + 4;
+                            let mut lines = s.lines();
+                            if let Some(line) = lines.next() {
+                                writeln!(buf, "\n{:>indent$}{line}", "").expect(
+                                    "writing to a string should always work",
+                                );
+                                for line in lines {
+                                    writeln!(buf, "{:>indent$}{line}", "").expect(
+                                        "writing to a string should always work",
+                                    );
+                                }
+                            }
+                        }
                     }
                     serde_json::Value::Number(n) => {
                         buf.push_str(&n.to_string());


### PR DESCRIPTION
This is an attempt to kind of ape the format of illumos' `fmdump -V` etc. Hopefully it's a bit less unpleasant than the previous weird quasi-JSON we were getting from `serde_json::Value`'s `fmt::Debug` implementation.

Previously, it looked like this:

```console
eliza@hekate ~/Code/oxide/management-gateway-service $ cargo run -p faux-mgs -- --interface eno1np0 --discovery-addr '[fe80::0c1d:deff:fef0:d921]:11111' ereports
   Compiling faux-mgs v0.1.2 (/home/eliza/Code/oxide/management-gateway-service/faux-mgs)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.21s
     Running `target/debug/faux-mgs --interface eno1np0 --discovery-addr '[fe80::0c1d:deff:fef0:d921]:11111' ereports`
May 15 10:14:04.283 INFO creating SP handle on interface eno1np0, component: faux-mgs
May 15 10:14:04.285 INFO initial discovery complete, addr: [fe80::c1d:deff:fef0:d921%2]:11111, interface: eno1np0, socket: control-plane-agent, component: faux-mgs
restart ID: 2d2519ee-728e-7022-cf35-85249acee3f7
restart IDs did not match (requested 00000000-0000-0000-0000-000000000000)
count: 11

ereports:
0x1: {
    "ereport_message_version": Number(0),
    "hubris_task_gen": Number(0),
    "hubris_task_name": String("packrat"),
    "hubris_uptime_ms": Number(0),
    "lost": Null,
}

0x2: {
    "bus": String("MainBusB"),
    "ereport_message_version": Number(0),
    "hubris_task_gen": Number(0),
    "hubris_task_name": String("ereportulator"),
    "hubris_uptime_ms": Number(370730),
    "k": String("hw.apollo.undervolt"),
    "n": Number(1),
    "v": Number(13),
    "volts": Number(0.0),
}
```

Now it looks like this:

```console
1d:deff:fef0:d921]:11111' ereports
   Compiling faux-mgs v0.1.2 (/home/eliza/Code/oxide/management-gateway-service/faux-mgs)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.22s
     Running `target/debug/faux-mgs --interface eno1np0 --discovery-addr '[fe80::0c1d:deff:fef0:d921]:11111' ereports`
May 15 09:48:14.430 INFO creating SP handle on interface eno1np0, component: faux-mgs
May 15 09:48:14.432 INFO initial discovery complete, addr: [fe80::c1d:deff:fef0:d921%2]:11111, interface: eno1np0, socket: control-plane-agent, component: faux-mgs
restart ID: 2d2519ee-728e-7022-cf35-85249acee3f7
restart IDs did not match (requested 00000000-0000-0000-0000-000000000000)
count: 11

ereports:
TIME         CLASS                                         ENA
0            <null>                                        0x0000000000000001

ereport_message_version = 0
hubris_task_gen = 0
hubris_task_name = packrat
hubris_uptime_ms = 0
lost = <null>

TIME         CLASS                                         ENA
370730       hw.apollo.undervolt                           0x0000000000000002

bus = MainBusB
ereport_message_version = 0
hubris_task_gen = 0
hubris_task_name = ereportulator
hubris_uptime_ms = 370730
class = hw.apollo.undervolt
n = 1
version = 13
volts = 0.0
```

Closes #493 